### PR TITLE
Interpolator vectorization and tests

### DIFF
--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -82,8 +82,7 @@ def create_transit_net(gtfsfeeds_df=None,day=None,timerange=None,overwrite_exist
     if gtfsfeeds_df.stop_times_int.empty or overwrite_existing_stop_times_int or use_existing_stop_times_int == False:
         gtfsfeeds_df.stop_times_int = interpolatestoptimes(stop_times_df=gtfsfeeds_df.stop_times,
                                                            calendar_selected_trips_df=calendar_selected_trips_df,
-                                                           day=day,
-                                                           verbose=False)
+                                                           day=day)
 
         gtfsfeeds_df.stop_times_int = timedifference(stop_times_df=gtfsfeeds_df.stop_times_int)
 
@@ -177,7 +176,7 @@ def tripschedualselector(input_trips_df=None,input_calendar_df=None,day=None):
 
     return calendar_selected_trips_df
 
-def interpolatestoptimes(stop_times_df=None,calendar_selected_trips_df=None,day=None,verbose=False):
+def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
     """
     Interpolate missing stop times using a linear interpolator between known stop times
 

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -188,15 +188,12 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
         dataframe of trips that run on specific day
     day : {'friday','monday','saturday','sunday','thursday','tuesday','wednesday'}
         day of the week to extract transit schedule from that corresponds to the day in the GTFS calendar
-    verbose : bool
-        if true, all trips that are interpolated will be printed out for reference. should only be used for debugging
 
     Returns
     -------
     final_stop_times_df : pandas.DataFrame
 
     """
-    #TODO: Optimize interpolator for speed
 
     start_time = time.time()
 
@@ -229,10 +226,6 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
                                                                             (stop_times_df['departure_time_sec'].isnull().sum() / len(stop_times_df)) *100,
                                                                             len(stop_times_df['departure_time_sec'])))
 
-    # create empty series to hold the interpolated departure times for each
-    # trip id generated below
-    all_trip_int_series = pd.Series()
-    # loop over all unique trips in stop time df
     log('Interpolating...')
 
     # Find trips with more than one missing time
@@ -279,7 +272,7 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
     final_stop_times_df['departure_time_sec_interpolate'].fillna(final_stop_times_df['departure_time_sec'], inplace=True)
 
     if final_stop_times_df['departure_time_sec_interpolate'].isnull().sum() > 0:
-        log('WARNING: Number of records unable to interpolate: {}. These records have been removed.'.format(final_stop_times_df['departure_time_sec_interpolate'].isnull().sum()),level=lg.WARNING)
+        log('WARNING: Number of records unable to interpolate: {:,}. These records have been removed.'.format(final_stop_times_df['departure_time_sec_interpolate'].isnull().sum()),level=lg.WARNING)
 
     ## convert the interpolated times (float) to integer so all times are the same number format
     # first run int converter on non-null records (nulls here are the last stop times in a trip because there is no departure)

--- a/urbanaccess/tests/test_gtfs_network.py
+++ b/urbanaccess/tests/test_gtfs_network.py
@@ -1,0 +1,62 @@
+import pytest
+import pandas as pd
+import numpy as np
+from urbanaccess.gtfs import network
+
+
+@pytest.fixture
+def stop_times():
+    data = {
+        'unique_agency_id': ['citytrains'] * 20,
+        'trip_id': ['a', 'a', 'a', 'a', 'a',
+                    'b', 'b', 'b', 'b', 'b',
+                    'c', 'c', 'c', 'c', 'c',
+                    'd', 'd', 'd', 'd', 'd'],
+        'stop_id': range(20),
+        'departure_time_sec': [1, 2, np.nan, np.nan, 5,
+                               1, 2, 3, 4, np.nan,
+                               np.nan, np.nan, 3, 4, np.nan,
+                               1, 2, 3, 4, 5],
+        'stop_sequence': [1, 2, 3, 4, 5] * 4
+    }
+    index = range(20)
+
+    df = pd.DataFrame(data, index)
+    return df
+
+
+@pytest.fixture
+def calendar():
+    data = {
+        'unique_agency_id': ['citytrains'] * 3,
+        'trip_id': ['a', 'b', 'c']
+    }
+    index = range(3)
+
+    df = pd.DataFrame(data, index)
+    return df
+
+
+def test_interpolator(stop_times, calendar):
+    df = network.interpolatestoptimes(stop_times, calendar, day='monday')
+
+    # unique_trip_id should be generated
+    assert df.loc[1, 'unique_trip_id'] == 'a_citytrains'
+
+    # trip 'a' should be interpolated fully
+    assert df.loc[df.trip_id == 'a',
+                  'departure_time_sec_interpolate'].tolist() == [1, 2, 3, 4, 5]
+
+    # trip 'b' should be skipped because it has only one null value
+    # but its null value should be removed
+    assert df.loc[df.trip_id == 'b',
+                  'departure_time_sec_interpolate'].tolist() == [1, 2, 3, 4]
+
+    # trip 'c' should be interpolated
+    # no starting value, so first two times removed
+    # missing value at end should be equal to last existing value
+    assert df.loc[df.trip_id == 'c',
+                  'departure_time_sec_interpolate'].tolist() == [3, 4, 4]
+
+    # trip 'd' should be removed because it's not in the calendar df
+    assert len(df.loc[df.trip_id == 'd']) == 0


### PR DESCRIPTION
Another speed improvement to the interpolator function. This change fully vectorizes the interpolation: a DataFrame is created in which each column represents a `unique_trip_id` and the index is `stop_sequence`. Running `DataFrame.interpolate()` interpolates values on all trips at once, and the values are merged back. 

I added a few unit tests for this function as well. @sablanchard it would be helpful to look over the return values to make sure they're behaving as intended.