### PR TITLE
Fix interpolation of trailing NAs for each trip

### DIFF
--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -251,15 +251,31 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
                                      limit_direction='forward')
 
     # Melt back into stacked format
-    interpolator['stop_sequence'] = interpolator.index
-    melted = pd.melt(interpolator, id_vars='stop_sequence')
+    interpolator['stop_sequence_merge'] = interpolator.index
+    melted = pd.melt(interpolator, id_vars='stop_sequence_merge')
     melted.rename(columns={'value': 'departure_time_sec_interpolate'},
                   inplace=True)
+
+    # Get the last valid stop for each unique trip, to filter out trailing NaNs
+    last_valid_stop_series = pivot.apply(
+        lambda col: col.last_valid_index(), axis=0)
+    last_valid_stop_df = last_valid_stop_series.to_frame('last_valid_stop')
+
+    df_for_interpolation = df_for_interpolation.merge(last_valid_stop_df,
+                                                      left_on='unique_trip_id',
+                                                      right_index=True)
+    trailing = (df_for_interpolation.stop_sequence >
+                df_for_interpolation.last_valid_stop)
+
+    # Calculate a stop_sequence without trailing NaNs, to merge the correct
+    # interpolated times back in
+    df_for_interpolation['stop_sequence_merge'] = (
+        df_for_interpolation[~trailing]['stop_sequence'])
 
     # Merge back into original index
     df_for_interpolation.reset_index(inplace=True)
     interpolated_df = pd.merge(df_for_interpolation, melted, 'left',
-                               on=['stop_sequence', 'unique_trip_id'])
+                               on=['stop_sequence_merge', 'unique_trip_id'])
     interpolated_df.set_index('index', inplace=True)
     interpolated_times = interpolated_df[['departure_time_sec_interpolate']]
 

--- a/urbanaccess/tests/test_gtfs_network.py
+++ b/urbanaccess/tests/test_gtfs_network.py
@@ -7,19 +7,21 @@ from urbanaccess.gtfs import network
 @pytest.fixture
 def stop_times():
     data = {
-        'unique_agency_id': ['citytrains'] * 20,
+        'unique_agency_id': ['citytrains'] * 25,
         'trip_id': ['a', 'a', 'a', 'a', 'a',
                     'b', 'b', 'b', 'b', 'b',
                     'c', 'c', 'c', 'c', 'c',
-                    'd', 'd', 'd', 'd', 'd'],
-        'stop_id': range(20),
+                    'd', 'd', 'd', 'd', 'd',
+                    'e', 'e', 'e', 'e', 'e'],
+        'stop_id': range(25),
         'departure_time_sec': [1, 2, np.nan, np.nan, 5,
                                1, 2, 3, 4, np.nan,
                                np.nan, np.nan, 3, 4, np.nan,
-                               1, 2, 3, 4, 5],
-        'stop_sequence': [1, 2, 3, 4, 5] * 4
+                               1, 2, 3, 4, 5,
+                               1, np.nan, 3, 4, np.nan],
+        'stop_sequence': [1, 2, 3, 4, 5] * 5
     }
-    index = range(20)
+    index = range(25)
 
     df = pd.DataFrame(data, index)
     return df
@@ -28,10 +30,10 @@ def stop_times():
 @pytest.fixture
 def calendar():
     data = {
-        'unique_agency_id': ['citytrains'] * 3,
-        'trip_id': ['a', 'b', 'c']
+        'unique_agency_id': ['citytrains'] * 4,
+        'trip_id': ['a', 'b', 'c', 'e']
     }
-    index = range(3)
+    index = range(4)
 
     df = pd.DataFrame(data, index)
     return df
@@ -54,9 +56,13 @@ def test_interpolator(stop_times, calendar):
 
     # trip 'c' should be interpolated
     # no starting value, so first two times removed
-    # missing value at end should be equal to last existing value
+    # NaN values should be removed from start and end
     assert df.loc[df.trip_id == 'c',
-                  'departure_time_sec_interpolate'].tolist() == [3, 4, 4]
+                  'departure_time_sec_interpolate'].tolist() == [3, 4]
 
     # trip 'd' should be removed because it's not in the calendar df
     assert len(df.loc[df.trip_id == 'd']) == 0
+
+    # trip 'e' should interpolate the second row but leave off the trailing NA
+    assert df.loc[df.trip_id == 'e',
+                  'departure_time_sec_interpolate'].tolist() == [1, 2, 3, 4]


### PR DESCRIPTION
Addresses #6. Adds a couple steps to the interpolator function to make sure interpolated values past the last valid departure time are not merged back in to the main DataFrame. Unit test is also modified with a new type of trip.