### PR TITLE
enable utils_format.py and load.gtfsfeed_to_df to complete successfully

### DIFF
--- a/urbanaccess/gtfs/utils_format.py
+++ b/urbanaccess/gtfs/utils_format.py
@@ -416,7 +416,7 @@ def add_unique_agencyid(agency_df=None,stops_df=None,routes_df=None,trips_df=Non
 
             calendar_dates_df = calendar_dates_agencyid(calendar_dates_df=calendar_dates_df,
                                                         routes_df=routes_df[['route_id', 'agency_id']],
-                                                        trips_df=trips_df[['trip_id', 'route_id']],
+                                                        trips_df=trips_df[['trip_id', 'route_id', 'service_id']],
                                                         agency_df=agency_df[['agency_id','agency_name']])
 
             calendar_df = calendar_agencyid(calendar_df=calendar_df,

--- a/urbanaccess/gtfs/utils_format.py
+++ b/urbanaccess/gtfs/utils_format.py
@@ -238,7 +238,7 @@ def calendar_agencyid(calendar_df=None,routes_df=None,trips_df=None,agency_df=No
     """
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
     tmp2 = pd.merge(trips_df, tmp1, how='left', on='route_id', sort=False, copy=False)
-    merged_df = pd.merge(calendar_df['service_id'], tmp2, how='left', on='service_id', sort=False, copy=False)
+    merged_df = pd.merge(calendar_df[['service_id']], tmp2, how='left', on='service_id', sort=False, copy=False)
     merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='service_id', keep='first', inplace=True)
 
@@ -347,7 +347,7 @@ def stop_times_agencyid(stop_times_df=None, routes_df=None,trips_df=None, agency
     merged_df : pandas.DataFrame
     """
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
-    tmp2 = pd.merge(trips_df['trip_id'], tmp1, how='left', on='route_id', sort=False, copy=False)
+    tmp2 = pd.merge(trips_df[['trip_id', 'route_id']], tmp1, how='left', on='route_id', sort=False, copy=False)
     merged_df = pd.merge(stop_times_df, tmp2, how='left', on='trip_id', sort=False, copy=False)
     merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='trip_id', keep='first',inplace=True)
@@ -389,12 +389,16 @@ def add_unique_agencyid(agency_df=None,stops_df=None,routes_df=None,trips_df=Non
 
     df_list = [stops_df,routes_df,trips_df,stop_times_df,calendar_df,calendar_dates_df]
 
-    if ((os.path.exists(os.path.join(feed_folder,'agency.txt')) == False or
-                 'agency_id' not in agency_df.columns) and
-                nulls_as_folder == True):
-        for df in df_list:
+    path_absent = os.path.exists(os.path.join(feed_folder,'agency.txt')) == False
+    agency_absent = 'agency_id' not in agency_df.columns
+    if ((path_absent or agency_absent) and nulls_as_folder == True):
+
+        for index, df in enumerate(df_list):
+            # TODO: We seem to be repeating this pattern in a number of places - either do it once or use a helper function
             unique_agency_id = sub(r'\s+', '_', os.path.split(feed_folder)[1]).replace('&','and').lower()
             df['unique_agency_id'] = unique_agency_id
+            df_list[index] = df
+
         log('The agency.txt or agency_id column was not found. The unique agency id: {} was generated using the name of the folder containing the GTFS feed text files.'.format(unique_agency_id))
 
     elif os.path.exists(os.path.join(feed_folder,'agency.txt')) == False and nulls_as_folder == False:
@@ -407,12 +411,19 @@ def add_unique_agencyid(agency_df=None,stops_df=None,routes_df=None,trips_df=Non
 
         if len(agency_df['agency_name']) == 1:
             assert agency_df['agency_name'].isnull().values == False
+
+            # TODO: Again, this need to be moved into a helper function
             unique_agency_id = sub(r'\s+', '_', agency_df['agency_name'][0]).replace('&','and').lower()
-            for df in df_list:
+
+            for index, df in enumerate(df_list):
                 df['unique_agency_id'] = unique_agency_id
+                df_list[index] = df
             log('The unique agency id: {} was generated using the name of the agency in the agency.txt file.'.format(unique_agency_id))
 
         elif len(agency_df['agency_name']) > 1:
+            # TODO: Assertions shouldn't be in runtime - validation should 
+            #       either be prior to model execution or handled gracefully
+            #       through caught errors/exceptions
             assert agency_df[['agency_id','agency_name']].isnull().values.any() == False
 
             # TODO: In each of the steps, the functions foo_agencyid ought be prepended with an underscore (e.g.
@@ -425,7 +436,7 @@ def add_unique_agencyid(agency_df=None,stops_df=None,routes_df=None,trips_df=Non
 
             calendar_df = calendar_agencyid(calendar_df=calendar_df,
                                             routes_df=routes_df[['route_id', 'agency_id']],
-                                            trips_df=trips_df[['trip_id', 'route_id']],
+                                            trips_df=trips_df[['trip_id', 'route_id', 'service_id']],
                                             agency_df=agency_df[['agency_id','agency_name']])
             
             trips_df = trips_agencyid(trips_df=trips_df,
@@ -446,15 +457,25 @@ def add_unique_agencyid(agency_df=None,stops_df=None,routes_df=None,trips_df=Non
                                                 trips_df=trips_df[['trip_id', 'route_id']],
                                                 agency_df=agency_df[['agency_id','agency_name']])
 
+            # TODO: It's obfuscatory to update the dataframe variables in such a deeply nested way.
+            #       Perhaps a more clear naming convention here before df_list is overridden
+            #       would make this steps intent more explicit.
+
+            # need to update the df_list object with these new variable overrides
+            df_list = [stops_df,routes_df,trips_df,stop_times_df,calendar_df,calendar_dates_df]
+            
             log('agency.txt agency_name column has more than one agency name listed. Unique agency id was assigned using the agency id and associated agency name.')
 
-    for df in df_list:
+    for index, df in enumerate(df_list):
         if df['unique_agency_id'].isnull().values.any():
+            # TODO: These string conversions seem to follow a pattern, could be part of the helper function?
             unique_agency_id = sub(r'\s+', '_', os.path.split(feed_folder)[1]).replace('&','and').lower()
+
             df['unique_agency_id'].fillna(''.join(['multiple_operators_', unique_agency_id]), inplace=True)
             log('There are {} null values ({}% of total) without a unique agency id. '
                 'These records will be labeled as multiple_operators_ with the GTFS file folder '
                 'name'.format(df['unique_agency_id'].isnull().sum(),len(df),round((float(df['unique_agency_id'].isnull().sum()) / float(len(df)) *100))))
+            df_list[index] = df
 
     log('Unique agency id operation complete. Took {:,.2f} seconds'.format(time.time()-start_time))
     return stops_df,routes_df,trips_df,stop_times_df,calendar_df,calendar_dates_df

--- a/urbanaccess/gtfs/utils_format.py
+++ b/urbanaccess/gtfs/utils_format.py
@@ -239,7 +239,7 @@ def calendar_agencyid(calendar_df=None,routes_df=None,trips_df=None,agency_df=No
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
     tmp2 = pd.merge(trips_df, tmp1, how='left', on='route_id', sort=False, copy=False)
     merged_df = pd.merge(calendar_df['service_id'], tmp2, how='left', on='service_id', sort=False, copy=False)
-    merged_df['unique_agency_id'] = sub(r'\s+', '_', merged_df['agency_name']).str.replace('&','and').lower()
+    merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='service_id', keep='first', inplace=True)
 
     merged_df = pd.merge(calendar_df, merged_df[['unique_agency_id', 'service_id']], how='left',
@@ -266,7 +266,7 @@ def trips_agencyid(trips_df=None,routes_df=None, agency_df=None):
     """
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
     merged_df = pd.merge(trips_df[['trip_id', 'route_id']], tmp1, how='left', on='route_id', sort=False, copy=False)
-    merged_df['unique_agency_id'] = sub(r'\s+', '_', merged_df['agency_name']).str.replace('&','and').lower()
+    merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='trip_id', keep='first', inplace=True)
 
     merged_df = pd.merge(trips_df, merged_df[['unique_agency_id', 'trip_id']], how='left', on='trip_id',
@@ -298,7 +298,7 @@ def stops_agencyid(stops_df=None, trips_df=None, routes_df=None,stop_times_df=No
     tmp2 = pd.merge(trips_df, tmp1, how='left', on='route_id', sort=False, copy=False)
     tmp3 = pd.merge(stop_times_df, tmp2, how='left', on='trip_id', sort=False, copy=False)
     merged_df = pd.merge(stops_df[['stop_id']], tmp3, how='left', on='stop_id', sort=False, copy=False)
-    merged_df['unique_agency_id'] = sub(r'\s+', '_', merged_df['agency_name']).str.replace('&','and').lower()
+    merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='stop_id', keep='first', inplace=True)
 
     merged_df = pd.merge(stops_df, merged_df[['unique_agency_id', 'stop_id']], how='left', on='stop_id',
@@ -321,7 +321,7 @@ def routes_agencyid(routes_df=None, agency_df=None):
     merged_df : pandas.DataFrame
     """
     merged_df = pd.merge(routes_df[['route_id', 'agency_id']], agency_df, how='left', on='agency_id', sort=False, copy=False)
-    merged_df['unique_agency_id'] = sub(r'\s+', '_', merged_df['agency_name']).str.replace('&','and').lower()
+    merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
 
     merged_df = pd.merge(routes_df, merged_df[['unique_agency_id', 'route_id']], how='left', on='route_id',
                                      sort=False, copy=False)
@@ -349,7 +349,7 @@ def stop_times_agencyid(stop_times_df=None, routes_df=None,trips_df=None, agency
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
     tmp2 = pd.merge(trips_df['trip_id'], tmp1, how='left', on='route_id', sort=False, copy=False)
     merged_df = pd.merge(stop_times_df, tmp2, how='left', on='trip_id', sort=False, copy=False)
-    merged_df['unique_agency_id'] = sub(r'\s+', '_', merged_df['agency_name']).str.replace('&','and').lower()
+    merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='trip_id', keep='first',inplace=True)
 
     merged_df = pd.merge(stop_times_df, merged_df[['unique_agency_id','trip_id']], how='left', on='trip_id', sort=False, copy=False)


### PR DESCRIPTION
As I attempted to resolve the issue I noted in [this PR](https://github.com/UDST/urbanaccess/issues/10), I "unravelled" a number of components within `utils_format.py` that were broken. This PR fixes the errors insofar as it assumes that resolving the errors does not negatively affect the quality or accuracy of the output dataframes.

I noticed there is a Travis file. Also, looking through the tests, it looks like this segment my PR covers is missing tests. I'll make an effort to produce some tests to cover this component as well so that, in the future, modifications can be made on these components with confidence.

That said, I wanted to open the PR right now to "get the discussion going" and also ensure that my modifications were not in anyway creating observable negative downstream side effects (i.e. rows being left in the dataframes, etc.).

Issues being resolved in this PR:

1. In `calendar_dates_agencyid`, the merge with `tmp2` requires `service_id`, yet it is not provided in the prior dataframes used to create that variable.

2. Resolving that unveils another issue: The subsitution step in `calendar_dates_agencyid` includes the conversion of spaces to underscores: `sub(r'\s+', '_', col)`. This errors when performed on a dataframe column. I note that there are examples showing this is doable, perhaps it is not supported on some versions of Pandas. Because we don't specify exactly which version of each dependency we use (the greater than or equal option is used in the `requires.txt`), we should opt for a more conservative method in this step.

3. Resolving that step reveals a number of attempted merges on Series instead of dataframes. For example, this line in `calendar_agencyid`: `merged_df = pd.merge(calendar_df['service_id'], tmp2, how='left', on='service_id', sort=False, copy=False)`. `calendar_df['service_id']` returns a Pandas Series. It needs to be nested once more to retain the dataframe.

4. Line 426-5 has the same issue of their not being a `service_id` included in the initial few dataframes, as well.

5. `stop_times_agencyid` function attempts to merge a Series (`trips_df['trip_id']`) with a DataFrame, as well. 

6. Also, issue here (with same code from Item 5) is that you can't left join on `route_id` if it is not included at all in one of the dataframes.

7. The `elif len(agency_df['agency_name']) > 1:` logic segment never udpates the overall `df_list` global, resulting in a `KeyError` when looking for `unique_agency_id` in the next step.


