### PR TITLE
Prevent index name collision on index reset for interpolated df

### DIFF
--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -290,8 +290,14 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
     df_for_interpolation['stop_sequence_merge'] = (
         df_for_interpolation[~trailing]['stop_sequence'])
 
+    # Need to check if existing index in column names and drop if so (else
+    # a ValueError where Pandas can't insert b/c col already exists will occur)
+    drop_bool = False
+    if _check_if_index_name_in_cols(df_for_interpolation):
+        drop_bool = True
+    df_for_interpolation.reset_index(inplace=True, drop=drop_bool)
+
     # Merge back into original index
-    df_for_interpolation.reset_index(inplace=True)
     interpolated_df = pd.merge(df_for_interpolation, melted, 'left',
                                on=['stop_sequence_merge', 'unique_trip_id'])
     interpolated_df.set_index('index', inplace=True)
@@ -764,3 +770,9 @@ def load_processed_gtfs_data(dir=config.settings.data_folder,filename=None):
                 gtfsfeeds_df.calendar_dates = hdf5_to_df(dir=dir,filename=filename,key='calendar_dates')
 
     return gtfsfeeds_df
+
+# helper functions
+def _check_if_index_name_in_cols(df):
+    cols = df.columns.values
+    iname = df.index.name
+    return (iname in cols)

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -292,6 +292,7 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
 
     # Need to check if existing index in column names and drop if so (else
     # a ValueError where Pandas can't insert b/c col already exists will occur)
+    drop_bool = False
     if _check_if_index_name_in_cols(df_for_interpolation):
         # move the current index to own col named 'index'
         col_name_to_copy = df_for_interpolation.index.name

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -306,19 +306,9 @@ def interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
     interpolated_df.set_index('index', inplace=True)
     interpolated_times = interpolated_df[['departure_time_sec_interpolate']]
 
-    # default value for final_stop_times
-    final_stop_times_df = stop_times_df
-    
-    # if empty just duplicate departure_time_sec col
-    if interpolated_times.empty:
-        departures = final_stop_times_df['departure_time_sec'].copy()
-        final_stop_times_df['departure_time_sec_interpolate'] = departures
-    
-    # if df not empty, override the default final_stop_times with merge result
-    else:
-        final_stop_times_df = pd.merge(stop_times_df, interpolated_times,
-                                       how='left', left_index=True,
-                                       right_index=True, sort=False, copy=False)
+    final_stop_times_df = pd.merge(stop_times_df, interpolated_times,
+                                   how='left', left_index=True,
+                                   right_index=True, sort=False, copy=False)
 
     # fill in nulls in interpolated departure time column using trips that did not need interpolation in order to create
     # one column with both original and interpolated times


### PR DESCRIPTION
Small PR. In the associated file, `interpolatestoptimes` resets the dataframe `df_for_interpolation`. If `df_for_interpolation` is indexed by one of the columns, the `reset_index` operation will error because the existing column name will conflict with the one to be inserted during the index reset.

Here's an example traceback:
```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "urbanaccess/gtfs/network.py", line 301, in interpolatestoptimes
    df_for_interpolation.reset_index(inplace=True)
  File "/usr/local/lib/python2.7/site-packages/pandas/core/frame.py", line 3041, in reset_index
    new_obj.insert(0, name, values)
  File "/usr/local/lib/python2.7/site-packages/pandas/core/frame.py", line 2511, in insert
    allow_duplicates=allow_duplicates)
  File "/usr/local/lib/python2.7/site-packages/pandas/core/internals.py", line 3763, in insert
    raise ValueError('cannot insert %s, already exists' % item)
ValueError: cannot insert unique_trip_id, already exists
```

By setting `drop` to `True`, we avoid this.