### PR TITLE
Enable service ids from calendar dates

### DIFF
--- a/urbanaccess/gtfs/headways.py
+++ b/urbanaccess/gtfs/headways.py
@@ -4,7 +4,7 @@ import time
 import logging as lg
 
 from urbanaccess.utils import log
-from urbanaccess.gtfs.network import _timeselector
+from urbanaccess.gtfs.network import _time_selector
 
 warnings.simplefilter(action = "ignore", category = FutureWarning)
 
@@ -89,7 +89,7 @@ def _headway_handler(interpolated_stop_times_df, trips_df,
     columns = ['unique_route_id','route_long_name','route_type','unique_agency_id']
     routes_df = routes_df[columns]
 
-    selected_interpolated_stop_times_df = _timeselector(df=interpolated_stop_times_df, starttime=headway_timerange[0], endtime=headway_timerange[1])
+    selected_interpolated_stop_times_df = _time_selector(df=interpolated_stop_times_df, starttime=headway_timerange[0], endtime=headway_timerange[1])
 
     tmp1 = pd.merge(trips_df, routes_df, how='left', left_on='unique_route_id', right_on='unique_route_id', sort=False)
     merge_df = pd.merge(selected_interpolated_stop_times_df, tmp1, how='left',

--- a/urbanaccess/gtfs/load.py
+++ b/urbanaccess/gtfs/load.py
@@ -97,7 +97,9 @@ def _txt_header_whitespace_check(csv_rootpath=os.path.join(config.settings.data_
                 f.writelines(lines)
     log('GTFS text file header whitespace check completed. Took {:,.2f} seconds'.format(time.time()-start_time))
 
-def gtfsfeed_to_df(gtfsfeed_path=None,validation=False,verbose=True,bbox=None,remove_stops_outsidebbox=None,append_definitions=False):
+def gtfsfeed_to_df(gtfsfeed_path=None, validation=False, verbose=True,
+                   bbox=None, remove_stops_outsidebbox=None,
+                   append_definitions=False):
     """
     Read all GTFS feed components as a dataframe in a gtfsfeeds_dfs object and
     merge all individual GTFS feeds into a regional metropolitan data table.
@@ -125,8 +127,9 @@ def gtfsfeed_to_df(gtfsfeed_path=None,validation=False,verbose=True,bbox=None,re
     remove_stops_outsidebbox : bool
         if true stops that are outside the bbox will be removed
     append_definitions : bool
-        if true, columns that use the GTFS data schema for their attribute codes will have the corresponding GTFS
-        definition information of that code appended to the resulting dataframes for reference
+        if true, columns that use the GTFS data schema for their attribute
+        codes will have the corresponding GTFS definition information of
+        that code appended to the resulting dataframes for reference
 
     Returns
     -------

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -33,12 +33,13 @@ def create_transit_net(gtfsfeeds_dfs, day,
         day of the week to extract transit schedule from that
         corresponds to the day in the GTFS calendar
     calendar_dates_lookup : dict, optional
-        dictionary of the lookup column (key) and corresponding string (
-        value) to use to subset trips using the calendar_dates dataframe.
-        search will be exact. If none, then the calendar_dates dataframe
-        will not be used to select trips that are not in the calendar
-        dataframe but that are in the calendar_dates dataframe.
-        example: {'schedule_type' : 'WD'}
+        dictionary of the lookup column (key) as a string and corresponding
+        string (value) a s string or list of strings to use to subset trips
+        using the calendar_dates dataframe. Search will be exact. If none,
+        then the calendar_dates dataframe will not be used to select trips
+        that are not in the calendar dataframe but that are in the
+        calendar_dates dataframe.
+        Example: {'schedule_type' : 'WD'} or {'schedule_type' : ['WD','SU']}
     timerange : list
         time range to extract transit schedule from in a list with time
         1 and time 2. it is suggested the time range

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -224,7 +224,7 @@ def _trip_schedule_selector(input_trips_df, input_calendar_df,
             raise ValueError('calendar_dates_lookup parameter is not a dict')
         for key in calendar_dates_lookup.keys():
             if not isinstance(key, str):
-                raise ValueError('{} calendar_dates_lookup key must be a '
+                raise ValueError('calendar_dates_lookup key {} must be a '
                                  'string'.format(key))
 
             if isinstance(calendar_dates_lookup[key], str):
@@ -232,7 +232,7 @@ def _trip_schedule_selector(input_trips_df, input_calendar_df,
             else:
                 if not isinstance(calendar_dates_lookup[key], list):
                     raise ValueError(
-                        '{} calendar_dates_lookup value must be a string or a '
+                        'calendar_dates_lookup value {} must be a string or a '
                         'list of strings'.format(
                             calendar_dates_lookup[key]))
                 else:
@@ -245,11 +245,10 @@ def _trip_schedule_selector(input_trips_df, input_calendar_df,
     # create unique service ids
     df_list = [input_trips_df, input_calendar_df, input_calendar_dates_df]
 
-    for index, df in enumerate(df_list):
+    for df in df_list:
         df['unique_service_id'] = (df['service_id'].str.cat(
                 df['unique_agency_id'].astype('str'),
                 sep='_'))
-        df_list[index] = df
 
     # select service ids where day specified has a 1 = service runs on that day
     log('Using calendar to extract service_ids to select trips.')
@@ -390,11 +389,10 @@ def _interpolate_stop_times(stop_times_df, calendar_selected_trips_df, day):
     # create unique trip ids
     df_list = [calendar_selected_trips_df, stop_times_df]
 
-    for index, df in enumerate(df_list):
+    for df in df_list:
         df['unique_trip_id'] = (df['trip_id'].str.cat(
                 df['unique_agency_id'].astype('str'),
                 sep='_'))
-        df_list[index] = df
 
     # sort stop times inplace based on first to last stop in
     # sequence -- required as the linear interpolator runs

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -37,8 +37,7 @@ def create_transit_net(gtfsfeeds_dfs, day,
         string (value) a s string or list of strings to use to subset trips
         using the calendar_dates dataframe. Search will be exact. If none,
         then the calendar_dates dataframe will not be used to select trips
-        that are not in the calendar dataframe but that are in the
-        calendar_dates dataframe.
+        that are not in the calendar dataframe.
         Example: {'schedule_type' : 'WD'} or {'schedule_type' : ['WD','SU']}
     timerange : list
         time range to extract transit schedule from in a list with time
@@ -201,8 +200,7 @@ def _trip_schedule_selector(input_trips_df, input_calendar_df,
         string (value) a s string or list of strings to use to subset trips
         using the calendar_dates dataframe. Search will be exact. If none,
         then the calendar_dates dataframe will not be used to select trips
-        that are not in the calendar dataframe but that are in the
-        calendar_dates dataframe.
+        that are not in the calendar dataframe.
         Example: {'schedule_type' : 'WD'} or {'schedule_type' : ['WD','SU']}
 
     Returns

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -8,8 +8,8 @@ from urbanaccess.network import ua_network
 from urbanaccess import config
 from urbanaccess.gtfs.gtfsfeeds_dataframe import gtfsfeeds_dfs
 
-
 pd.options.mode.chained_assignment = None
+
 
 def create_transit_net(gtfsfeeds_dfs, day,
                        calendar_dates_lookup=None,
@@ -28,8 +28,8 @@ def create_transit_net(gtfsfeeds_dfs, day,
     gtfsfeeds_dfs : object
         gtfsfeeds_dfs object with dataframes of stops, routes, trips,
         stop_times, calendar, and stop_times_int (optional)
-    day : {'friday','monday','saturday', 'sunday',
-        'thursday','tuesday','wednesday'}
+    day : {'friday','monday','saturday', 'sunday','thursday','tuesday',
+    'wednesday'}
         day of the week to extract transit schedule from that
         corresponds to the day in the GTFS calendar
     calendar_dates_lookup : dict, optional
@@ -71,25 +71,33 @@ def create_transit_net(gtfsfeeds_dfs, day,
     """
     start_time = time.time()
 
-    time_error_statement = ('{} starttime and endtime are not in the correct format. '
-                       'Format should be 24 hour clock in following format: 08:00:00 or 17:00:00'.format(timerange))
-    assert isinstance(timerange,list) and len(timerange) == 2, time_error_statement
+    time_error_statement = (
+        '{} starttime and endtime are not in the correct format. '
+        'Format should be 24 hour clock in following format: 08:00:00 or '
+        '17:00:00'.format(
+            timerange))
+    assert isinstance(timerange, list) and len(
+        timerange) == 2, time_error_statement
     assert timerange[0] < timerange[1], time_error_statement
     for t in timerange:
-        assert isinstance(t,str), time_error_statement
+        assert isinstance(t, str), time_error_statement
         assert len(t) == 8, time_error_statement
     if int(str(timerange[1][0:2])) - int(str(timerange[0][0:2])) > 3:
-        log('WARNING: Time range passed: {} is a {} hour period. Long periods over 3 hours may take a '
-            'significant amount of time to process.'.format(timerange,
-                                                            int(str(timerange[1][0:2])) - int(str(timerange[0][0:2]))),level=lg.WARNING)
+        log((
+            'WARNING: Time range passed: {} is a {} hour period. Long '
+            'periods over 3 hours may take a significant amount of time to '
+            'process.').format(
+            timerange,
+            int(str(timerange[1][0:2])) - int(str(timerange[0][0:2]))),
+            level=lg.WARNING)
     assert gtfsfeeds_dfs is not None
     if gtfsfeeds_dfs.trips.empty or gtfsfeeds_dfs.calendar.empty or \
             gtfsfeeds_dfs.stop_times.empty or gtfsfeeds_dfs.stops.empty:
         raise ValueError('one of the gtfsfeeds_dfs object trips, calendar, '
                          'stops, or stop_times were found to be empty.')
-    assert isinstance(overwrite_existing_stop_times_int,bool)
-    assert isinstance(use_existing_stop_times_int,bool)
-    assert isinstance(save_processed_gtfs,bool)
+    assert isinstance(overwrite_existing_stop_times_int, bool)
+    assert isinstance(use_existing_stop_times_int, bool)
+    assert isinstance(save_processed_gtfs, bool)
 
     columns = ['route_id',
                'direction_id',
@@ -98,7 +106,7 @@ def create_transit_net(gtfsfeeds_dfs, day,
                'unique_agency_id']
     if 'direction_id' not in gtfsfeeds_dfs.trips.columns:
         columns.remove('direction_id')
-    calendar_selected_trips_df = _tripscheduleselector(
+    calendar_selected_trips_df = _trip_schedule_selector(
         input_trips_df=gtfsfeeds_dfs.trips[columns],
         input_calendar_df=gtfsfeeds_dfs.calendar,
         input_calendar_dates_df=gtfsfeeds_dfs.calendar_dates,
@@ -108,35 +116,37 @@ def create_transit_net(gtfsfeeds_dfs, day,
     if gtfsfeeds_dfs.stop_times_int.empty or \
             overwrite_existing_stop_times_int or \
                     use_existing_stop_times_int == False:
-        gtfsfeeds_dfs.stop_times_int = _interpolatestoptimes(
+        gtfsfeeds_dfs.stop_times_int = _interpolate_stop_times(
             stop_times_df=gtfsfeeds_dfs.stop_times,
             calendar_selected_trips_df=calendar_selected_trips_df,
             day=day)
 
-        gtfsfeeds_dfs.stop_times_int = _timedifference(
+        gtfsfeeds_dfs.stop_times_int = _time_difference(
             stop_times_df=gtfsfeeds_dfs.stop_times_int)
 
         if save_processed_gtfs:
             save_processed_gtfs_data(gtfsfeeds_dfs=gtfsfeeds_dfs,
-                                     dir=save_dir,filename=save_filename)
+                                     dir=save_dir, filename=save_filename)
 
     if use_existing_stop_times_int:
-        assert gtfsfeeds_dfs.stop_times_int.empty == False, 'existing ' \
-                                                            'stop_times_int is empty. ' \
-                                                           'set use_existing_stop_times_int to False to create it.'
+        assert gtfsfeeds_dfs.stop_times_int.empty == False, ('existing '
+                                                             'stop_times_int '
+                                                             'is empty. set '
+                                                             'use_existing_stop_times_int to False to create it.')
 
-    selected_interpolated_stop_times_df = _timeselector(
+    selected_interpolated_stop_times_df = _time_selector(
         df=gtfsfeeds_dfs.stop_times_int,
         starttime=timerange[0],
         endtime=timerange[1])
 
-    final_edge_table = _format_transit_net_edge(stop_times_df=selected_interpolated_stop_times_df[['unique_trip_id',
-                                                                                                  'stop_id',
-                                                                                                  'unique_stop_id',
-                                                                                                  'timediff',
-                                                                                                   'stop_sequence',
-                                                                                                   'unique_agency_id',
-                                                                                                   'trip_id']])
+    final_edge_table = _format_transit_net_edge(
+        stop_times_df=selected_interpolated_stop_times_df[['unique_trip_id',
+                                                           'stop_id',
+                                                           'unique_stop_id',
+                                                           'timediff',
+                                                           'stop_sequence',
+                                                           'unique_agency_id',
+                                                           'trip_id']])
 
     ua_network.transit_edges = _convert_imp_time_units(df=final_edge_table,
                                                        time_col='weight',
@@ -146,25 +156,30 @@ def create_transit_net(gtfsfeeds_dfs, day,
         input_stops_df=gtfsfeeds_dfs.stops,
         input_stop_times_df=selected_interpolated_stop_times_df)
 
-    ua_network.transit_nodes = _format_transit_net_nodes(df=final_selected_stops)
+    ua_network.transit_nodes = _format_transit_net_nodes(
+        df=final_selected_stops)
 
-    ua_network.transit_edges = _route_type_to_edge(transit_edge_df=ua_network.transit_edges,
-                                                   stop_time_df=gtfsfeeds_dfs.stop_times)
+    ua_network.transit_edges = _route_type_to_edge(
+        transit_edge_df=ua_network.transit_edges,
+        stop_time_df=gtfsfeeds_dfs.stop_times)
 
-    ua_network.transit_edges = _route_id_to_edge(transit_edge_df=ua_network.transit_edges,
-                                                 trips_df=gtfsfeeds_dfs.trips)
+    ua_network.transit_edges = _route_id_to_edge(
+        transit_edge_df=ua_network.transit_edges,
+        trips_df=gtfsfeeds_dfs.trips)
 
     # assign node and edge net type
     ua_network.transit_nodes['net_type'] = 'transit'
     ua_network.transit_edges['net_type'] = 'transit'
 
-    log('Successfully created transit network. Took {:,.2f} seconds'.format(time.time()-start_time))
+    log(('Successfully created transit network. Took {:,'
+         '.2f} seconds').format(time.time() - start_time))
 
     return ua_network
 
-def _tripscheduleselector(input_trips_df, input_calendar_df,
-                          input_calendar_dates_df, day,
-                          calendar_dates_lookup=None):
+
+def _trip_schedule_selector(input_trips_df, input_calendar_df,
+                            input_calendar_dates_df, day,
+                            calendar_dates_lookup=None):
     """
     Select trips that run on a specific day
 
@@ -176,17 +191,18 @@ def _tripscheduleselector(input_trips_df, input_calendar_df,
         calendar dataframe
     input_calendar_dates_df : pandas.DataFrame
         calendar_dates dataframe
-    day : {'friday','monday','saturday','sunday',
-        'thursday','tuesday','wednesday'}
+    day : {'friday','monday','saturday','sunday','thursday','tuesday',
+    'wednesday'}
         day of the week to extract transit schedule that corresponds to the
         day in the GTFS calendar
     calendar_dates_lookup : dict, optional
-        dictionary of the lookup column (key) and corresponding string (
-        value) to use to subset trips using the calendar_dates dataframe.
-        search will be exact. If none, then the calendar_dates dataframe
-        will not be used to select trips that are not in the calendar
-        dataframe but that are in the calendar_dates dataframe.
-        example: {'schedule_type' : 'WD'}
+        dictionary of the lookup column (key) as a string and corresponding
+        string (value) a s string or list of strings to use to subset trips
+        using the calendar_dates dataframe. Search will be exact. If none,
+        then the calendar_dates dataframe will not be used to select trips
+        that are not in the calendar dataframe but that are in the
+        calendar_dates dataframe.
+        Example: {'schedule_type' : 'WD'} or {'schedule_type' : ['WD','SU']}
 
     Returns
     -------
@@ -195,22 +211,48 @@ def _tripscheduleselector(input_trips_df, input_calendar_df,
     """
     start_time = time.time()
 
-    valid_days = ['friday','monday','saturday','sunday',
-                  'thursday','tuesday','wednesday']
-    assert day in valid_days and isinstance(day, str),'Incorrect day specified. Must be lowercase string: ' \
-                                                      'friday, monday, saturday, sunday, thursday, tuesday, wednesday.'
+    valid_days = ['friday', 'monday', 'saturday', 'sunday',
+                  'thursday', 'tuesday', 'wednesday']
 
+    if day not in valid_days and isinstance(day, str):
+        raise ValueError('Incorrect day specified. Must be one of lowercase '
+                         'strings: friday, monday, saturday, sunday, '
+                         'thursday, tuesday, wednesday.')
+
+    # check format of calendar_dates_lookup
     if calendar_dates_lookup is not None:
-        assert isinstance(calendar_dates_lookup,dict)
+        if not isinstance(calendar_dates_lookup, dict):
+            raise ValueError('calendar_dates_lookup parameter is not a dict')
         for key in calendar_dates_lookup.keys():
-            assert isinstance(key,str), ('{} must be a string').format(key)
-            for value in calendar_dates_lookup[key]:
-                assert isinstance(value,str), ('{} must be a string').format(value)
+            if not isinstance(key, str):
+                raise ValueError('{} must be a string'.format(key))
+
+            if isinstance(calendar_dates_lookup[key], str):
+                value = [calendar_dates_lookup[key]]
+            else:
+                if not isinstance(calendar_dates_lookup[key], list):
+                    raise ValueError('{} must be a string or a list of strings'.format(calendar_dates_lookup[key]))
+                else:
+                    value = calendar_dates_lookup[key]
+
+            for string in value:
+                if not isinstance(string, str):
+                    raise ValueError('{} must be a string'.format(value))
 
     # create unique service ids
-    input_trips_df['unique_service_id'] = input_trips_df[['service_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
-    input_calendar_df['unique_service_id'] = input_calendar_df[['service_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
-    input_calendar_dates_df['unique_service_id'] = input_calendar_dates_df[['service_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
+    #TODO: these dfs can be wrapped in a list
+    input_trips_df['unique_service_id'] = (
+        input_trips_df.service_id.str.cat(
+            input_trips_df.unique_agency_id.astype('str'),
+            sep='_'))
+    input_calendar_df['unique_service_id'] = (
+        input_calendar_df.service_id.str.cat(
+            input_calendar_df.unique_agency_id.astype('str'),
+            sep='_'))
+    input_calendar_dates_df['unique_service_id'] = (
+        input_calendar_dates_df.service_id.str.cat(
+            input_calendar_dates_df.unique_agency_id.astype('str'),
+            sep='_'))
 
     # select service ids where day specified has a 1 = service runs on that day
     log('Using calendar to extract service_ids to select trips.')
@@ -223,7 +265,7 @@ def _tripscheduleselector(input_trips_df, input_calendar_df,
     # terms of service_ids in calendar and calendar_dates tables
     trips_in_calendar = input_trips_df.loc[input_trips_df[
         'unique_service_id'].isin(
-            input_calendar_df['unique_service_id'])]
+        input_calendar_df['unique_service_id'])]
     trips_notin_calendar = input_trips_df.loc[~input_trips_df[
         'unique_service_id'].isin(input_calendar_df['unique_service_id'])]
 
@@ -232,23 +274,26 @@ def _tripscheduleselector(input_trips_df, input_calendar_df,
     pct_trips_notin_calendar = round(len(trips_notin_calendar) / len(
         input_trips_df) * 100, 3)
 
-    log('{:,} trip(s) {:.3f} percent of {:,} total trip records were ' \
-            'found in calendar'.format(len(trips_in_calendar),
-                                       pct_trips_in_calendar,len(
-            input_trips_df)))
+    log(('{:,} trip(s) {:.3f} percent of {:,} total trip records were found '
+         'in calendar').format(len(trips_in_calendar),
+                               pct_trips_in_calendar,
+                               len(input_trips_df)))
 
     if len(trips_notin_calendar) > 0 and calendar_dates_lookup is None:
-        log('NOTE: {:,} trip(s) {:.3f} percent of {:,} total trip records '
+        warning_msg = (
+            'NOTE: {:,} trip(s) {:.3f} percent of {:,} total trip records '
             'were found to be in calendar_dates and not calendar. The '
-            'calendar_dates_lookup parameter ' \
-            'is None. In order to use the trips inside the calendar_dates ' \
-            'dataframe it is suggested you specify a search parameter in the '
-            'calendar_dates_lookup dict. This should only be done if '
-            'you know the corresponding GTFS feed is using '
-            'calendar_dates instead of calendar to specify the '
-            'service_ids. When in doubt do not use this parameter.'.format(len(
-            trips_notin_calendar),pct_trips_notin_calendar,len(input_trips_df)),
-            level=lg.WARNING)
+            'calendar_dates_lookup parameter is None. In order to use the '
+            'trips inside the calendar_dates dataframe it is suggested you '
+            'specify a search parameter in the calendar_dates_lookup dict. '
+            'This should only be done if you know the corresponding '
+            'GTFS feed is using calendar_dates instead of calendar to '
+            'specify the service_ids. When in doubt do not use the '
+            'calendar_dates_lookup parameter.')
+        log(warning_msg.format(
+            len(trips_notin_calendar),
+            pct_trips_notin_calendar,
+            len(input_trips_df)), level=lg.WARNING)
 
     # look for service_ids inside of calendar_dates if calendar does not
     # supply enough service_ids to select trips by
@@ -260,21 +305,32 @@ def _tripscheduleselector(input_trips_df, input_calendar_df,
         subset_result_df = pd.DataFrame()
 
         for col_name_key, string_value in calendar_dates_lookup.items():
-           assert col_name_key in input_calendar_dates_df.columns, '{} column ' \
-                                                                   'not found in' \
-                                                                   ' ' \
-                                                                   'calendar_dates ' \
-                                                                   'dataframe'.format(col_name_key)
+            if col_name_key not in input_calendar_dates_df.columns:
+                raise ValueError(('{} column not found in calendar_dates '
+                                  'dataframe').format(col_name_key))
 
-           if col_name_key in input_calendar_dates_df.select_dtypes(include=[object]).columns:
-               subset_result = input_calendar_dates_df[input_calendar_dates_df[col_name_key].str.match(string_value,case=False,na=False)]
-               log('Found {:,} records that matched query: column: {} and '
-                   'string: {}'.format(len(subset_result),
-                                       col_name_key,
-                                       string_value))
-           subset_result_df = subset_result_df.append(subset_result)
-           subset_result_df.drop_duplicates(inplace=True)
-           subset_result_df = subset_result_df[['unique_service_id']]
+            if col_name_key not in input_calendar_dates_df.select_dtypes(
+                    include=[object]).columns:
+                raise ValueError('{} column is not object type'.format(
+                    col_name_key))
+
+            if not isinstance(string_value, list):
+                string_value = [string_value]
+
+            for text in string_value:
+
+                subset_result = input_calendar_dates_df[
+                    input_calendar_dates_df[col_name_key].str.match(
+                        text, case=False, na=False)]
+                log(('Found {:,} records that matched query: column: {} and '
+                     'string: {}').format(len(subset_result),
+                                          col_name_key,
+                                          text))
+
+                subset_result_df = subset_result_df.append(subset_result)
+
+        subset_result_df.drop_duplicates(inplace=True)
+        subset_result_df = subset_result_df[['unique_service_id']]
 
         log('{:,} service_ids were extracted from calendar_dates'.format(len(
             subset_result_df)))
@@ -284,30 +340,33 @@ def _tripscheduleselector(input_trips_df, input_calendar_df,
     # select and create df of trips that match the service ids for the day of
     # the week specified merge calendar df that has service ids for
     # specified day with trips df
-    calendar_selected_trips_df = input_trips_df.loc[input_trips_df['unique_service_id'].isin(input_calendar_df['unique_service_id'])]
+    calendar_selected_trips_df = input_trips_df.loc[
+        input_trips_df['unique_service_id'].isin(
+            input_calendar_df['unique_service_id'])]
 
     sort_columns = ['route_id', 'trip_id', 'direction_id']
     if 'direction_id' not in calendar_selected_trips_df.columns:
         sort_columns.remove('direction_id')
     calendar_selected_trips_df.sort_values(by=sort_columns, inplace=True)
-    calendar_selected_trips_df.reset_index(drop=True,inplace=True)
+    calendar_selected_trips_df.reset_index(drop=True, inplace=True)
     calendar_selected_trips_df.drop('unique_service_id', axis=1, inplace=True)
 
     if calendar_dates_lookup is None:
-        log('{:,} of {:,} total trips were extracted representing calendar '
-            'day: {}. Took {:,.2f} seconds'.format(len(
-            calendar_selected_trips_df),len(input_trips_df),
-            day,time.time()-start_time))
+        log(('{:,} of {:,} total trips were extracted representing calendar '
+             'day: {}. Took {:,.2f} seconds').format(len(
+            calendar_selected_trips_df), len(input_trips_df),
+            day, time.time() - start_time))
     else:
-        log('{:,} of {:,} total trips were extracted representing calendar '
-            'day: {} and calendar_dates search parameters: {}. Took {:,'
-            '.2f} seconds'.format(len(
-            calendar_selected_trips_df),len(input_trips_df),
-            day,calendar_dates_lookup, time.time()-start_time))
+        log(('{:,} of {:,} total trips were extracted representing calendar '
+             'day: {} and calendar_dates search parameters: {}. Took {:,'
+             '.2f} seconds').format(len(
+            calendar_selected_trips_df), len(input_trips_df),
+            day, calendar_dates_lookup, time.time() - start_time))
 
     return calendar_selected_trips_df
 
-def _interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
+
+def _interpolate_stop_times(stop_times_df, calendar_selected_trips_df, day):
     """
     Interpolate missing stop times using a linear
     interpolator between known stop times
@@ -318,8 +377,8 @@ def _interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
         stop times dataframe
     calendar_selected_trips_df : pandas.DataFrame
         dataframe of trips that run on specific day
-    day : {'friday','monday','saturday','sunday','thursday',
-        'tuesday','wednesday'}
+    day : {'friday','monday','saturday','sunday','thursday','tuesday',
+    'wednesday'}
         day of the week to extract transit schedule from that corresponds
         to the day in the GTFS calendar
 
@@ -350,28 +409,47 @@ def _interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
             'stop_sequence records missing in the stop_times dataframe. '
             'Please check these missing values. In order for interpolation '
             'to proceed correctly, '
-            'all records must have a stop_sequence value.'.format(stop_times_df['stop_sequence'].isnull().sum()),level=lg.WARNING)
+            'all records must have a stop_sequence value.'.format(
+            stop_times_df['stop_sequence'].isnull().sum()), level=lg.WARNING)
 
-    stop_times_df.sort_values(by=['unique_trip_id', 'stop_sequence'], inplace=True)
+    stop_times_df.sort_values(by=['unique_trip_id', 'stop_sequence'],
+                              inplace=True)
     # make list of unique trip ids from the calendar_selected_trips_df
-    uniquetriplist = calendar_selected_trips_df['unique_trip_id'].unique().tolist()
+    uniquetriplist = calendar_selected_trips_df[
+        'unique_trip_id'].unique().tolist()
     # select trip ids that match the trips in the
     # calendar_selected_trips_df -- resulting df will be stop times
     # only for trips that run on the service day of interest
-    stop_times_df = stop_times_df[stop_times_df['unique_trip_id'].isin(uniquetriplist)]
+    stop_times_df = stop_times_df[
+        stop_times_df['unique_trip_id'].isin(uniquetriplist)]
 
-    log('Note: Processing may take a long time depending'
-        ' on the number of records. '
-        'Total unique trips to assess: {:,}'.format(len(stop_times_df['unique_trip_id'].unique())),level=lg.WARNING)
-    log('Starting departure stop time interpolation...')
-    log('Departure time records missing from trips following'
-        ' {} schedule: {:,} '
-        '({:.2f} percent of {:,} total records)'.format(day,
-                                                        stop_times_df['departure_time_sec'].isnull().sum(),
-                                                        (stop_times_df['departure_time_sec'].isnull().sum() / len(stop_times_df)) *100,
-                                                        len(stop_times_df['departure_time_sec'])))
+    # count missing stop times
+    missing_stop_times_count = stop_times_df[
+        'departure_time_sec'].isnull().sum()
 
-    log('Interpolating...')
+    # if there are stop times missing that need interpolation notify user
+    if missing_stop_times_count > 0:
+
+        log('Note: Processing may take a long time depending'
+            ' on the number of records. '
+            'Total unique trips to assess: {:,}'.format(
+            len(stop_times_df['unique_trip_id'].unique())), level=lg.WARNING)
+        log('Starting departure stop time interpolation...')
+        log((
+                'Departure time records missing from trips following {} '
+                'schedule: {:,} ({:.2f} percent of {:,} total '
+                'records)').format(
+            day, missing_stop_times_count,
+            (missing_stop_times_count / len(stop_times_df)) * 100,
+            len(stop_times_df['departure_time_sec'])))
+
+        log('Interpolating...')
+
+    else:
+
+        log('There are no departure time records missing from trips '
+            'following {} schedule. There are no records to '
+            'interpolate.'.format(day))
 
     # Find trips with more than one missing time
     # Note: all trip ids have at least 1 null departure time because the
@@ -451,30 +529,49 @@ def _interpolatestoptimes(stop_times_df, calendar_selected_trips_df, day):
         final_stop_times_df['departure_time_sec_interpolate'] = (
             final_stop_times_df['departure_time_sec'])
 
-    # fill in nulls in interpolated departure time column using trips that did not need interpolation in order to create
+    # fill in nulls in interpolated departure time column using trips that
+    # did not need interpolation in order to create
     # one column with both original and interpolated times
-    final_stop_times_df['departure_time_sec_interpolate'].fillna(final_stop_times_df['departure_time_sec'], inplace=True)
+    final_stop_times_df['departure_time_sec_interpolate'].fillna(
+        final_stop_times_df['departure_time_sec'], inplace=True)
 
-    if final_stop_times_df['departure_time_sec_interpolate'].isnull().sum() > 0:
-        log('WARNING: Number of records unable to interpolate: {:,}. '
-            'These records have been removed.'.format(final_stop_times_df['departure_time_sec_interpolate'].isnull().sum()),level=lg.WARNING)
+    if final_stop_times_df[
+        'departure_time_sec_interpolate'].isnull().sum() > 0:
+        log(
+            'WARNING: Number of records unable to interpolate: {:,}. These '
+            'records have been removed.'.format(
+                final_stop_times_df[
+                    'departure_time_sec_interpolate'].isnull().sum()),
+            level=lg.WARNING)
 
-    ## convert the interpolated times (float) to integer so all times are the same number format
-    # first run int converter on non-null records (nulls here are the last stop times in a trip because there is no departure)
-    final_stop_times_df = final_stop_times_df[final_stop_times_df['departure_time_sec_interpolate'].notnull()]
+    # convert the interpolated times (float) to integer so all times are
+    # the same number format
+    # first run int converter on non-null records (nulls here are the last
+    # stop times in a trip because there is no departure)
+    final_stop_times_df = final_stop_times_df[
+        final_stop_times_df['departure_time_sec_interpolate'].notnull()]
     # convert float to int
-    final_stop_times_df['departure_time_sec_interpolate'] = final_stop_times_df['departure_time_sec_interpolate'].astype(int)
+    final_stop_times_df['departure_time_sec_interpolate'] = \
+    final_stop_times_df['departure_time_sec_interpolate'].astype(int)
 
     # add unique stop id
-    final_stop_times_df['unique_stop_id'] = final_stop_times_df[['stop_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
+    final_stop_times_df['unique_stop_id'] = final_stop_times_df[
+        ['stop_id', 'unique_agency_id']].apply(
+        lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
 
-    log('Departure stop time interpolation complete. Took {:,.2f} seconds'.format(time.time()-start_time))
+    if missing_stop_times_count > 0:
+        log(
+            'Departure stop time interpolation complete. Took {:,'
+            '.2f} seconds'.format(
+                time.time() - start_time))
 
     return final_stop_times_df
 
-def _timedifference(stop_times_df=None):
+
+def _time_difference(stop_times_df=None):
     """
-    Calculate the difference in departure_time between stops in stop times table to produce travel time
+    Calculate the difference in departure_time between stops in stop times
+    table to produce travel time
 
     Parameters
     ----------
@@ -488,13 +585,18 @@ def _timedifference(stop_times_df=None):
     """
     start_time = time.time()
 
-    ## calculate difference between consecutive records grouping by trip id.
-    stop_times_df['timediff'] = stop_times_df.groupby('unique_trip_id')['departure_time_sec_interpolate'].diff()
-    log('Difference between stop times has been successfully calculated. Took {:,.2f} seconds'.format(time.time()-start_time))
+    # calculate difference between consecutive records grouping by trip id.
+    stop_times_df['timediff'] = stop_times_df.groupby('unique_trip_id')[
+        'departure_time_sec_interpolate'].diff()
+    log(
+        'Difference between stop times has been successfully calculated. '
+        'Took {:,.2f} seconds'.format(
+            time.time() - start_time))
 
     return stop_times_df
 
-def _timeselector(df=None, starttime=None, endtime=None):
+
+def _time_selector(df=None, starttime=None, endtime=None):
     """
     Select stop times that fall within a specified time range
 
@@ -513,10 +615,12 @@ def _timeselector(df=None, starttime=None, endtime=None):
     """
     start_time = time.time()
 
-    # takes input start and end time range from 24 hour clock and converts it to seconds past midnight
+    # takes input start and end time range from 24 hour clock and converts
+    # it to seconds past midnight
     # in order to select times that may be after midnight
 
-    # convert string time components to integer and then calculate seconds past midnight
+    # convert string time components to integer and then calculate seconds
+    # past midnight
     # convert starttime 24 hour to seconds past midnight
     start_h = int(str(starttime[0:2]))
     start_m = int(str(starttime[3:5]))
@@ -529,9 +633,17 @@ def _timeselector(df=None, starttime=None, endtime=None):
     endtime_sec = (end_h * 60 * 60) + (end_m * 60) + end_s
 
     # create df of stops times that are within the requested range
-    selected_stop_timesdf = df[(( starttime_sec < df["departure_time_sec_interpolate"]) & (df["departure_time_sec_interpolate"] < endtime_sec ))]
+    selected_stop_timesdf = df[(
+    (starttime_sec < df["departure_time_sec_interpolate"]) & (
+    df["departure_time_sec_interpolate"] < endtime_sec))]
 
-    log('Stop times from {} to {} successfully selected {:,} records out of {:,} total records ({:.2f} percent of total). Took {:,.2f} seconds'.format(starttime,endtime,len(selected_stop_timesdf),len(df),(len(selected_stop_timesdf) / len(df)) * 100,time.time()-start_time))
+    log(
+        'Stop times from {} to {} successfully selected {:,} records out of '
+        '{:,} total records ({:.2f} percent of total). Took {:,'
+        '.2f} seconds'.format(
+            starttime, endtime, len(selected_stop_timesdf), len(df),
+            (len(selected_stop_timesdf) / len(df)) * 100,
+            time.time() - start_time))
 
     return selected_stop_timesdf
 
@@ -564,30 +676,33 @@ def _format_transit_net_edge(stop_times_df=None):
                               inplace=True)
 
     for trip, tmp_trip_df in stop_times_df.groupby(['unique_trip_id']):
-
         edge_df = pd.DataFrame({
             "node_id_from": tmp_trip_df['unique_stop_id'].iloc[:-1].values,
             "node_id_to": tmp_trip_df['unique_stop_id'].iloc[1:].values,
             "weight": tmp_trip_df['timediff'].iloc[1:].values,
-            "unique_agency_id": tmp_trip_df['unique_agency_id'].iloc[1:].values,
+            "unique_agency_id": tmp_trip_df['unique_agency_id'].iloc[
+                                1:].values,
             # set unique trip id without edge order to join other data later
             "unique_trip_id": trip
         })
 
         # Set current trip id to edge id column adding edge order at
         # end of string
-        edge_df['sequence'] = (edge_df.index+1).astype(int)
+        edge_df['sequence'] = (edge_df.index + 1).astype(int)
 
         # append completed formatted edge table to master edge table
         merged_edge.append(edge_df)
 
     merged_edge_df = pd.concat(merged_edge, ignore_index=True)
-    merged_edge_df['sequence'] = merged_edge_df['sequence'].astype(int, copy=False)
-    merged_edge_df['id'] = merged_edge_df[['unique_trip_id', 'sequence']].apply(lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
+    merged_edge_df['sequence'] = merged_edge_df['sequence'].astype(int,
+                                                                   copy=False)
+    merged_edge_df['id'] = merged_edge_df[
+        ['unique_trip_id', 'sequence']].apply(
+        lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
 
     log('stop time table transformation to '
         'Pandana format edge table completed. '
-        'Took {:,.2f} seconds'.format(time.time()-start_time))
+        'Took {:,.2f} seconds'.format(time.time() - start_time))
 
     return merged_edge_df
 
@@ -610,8 +725,8 @@ def _convert_imp_time_units(df=None, time_col='weight', convert_to='minutes'):
     df : pandas.DataFrame
 
     """
-    valid_convert_to = ['seconds','minutes']
-    assert convert_to in valid_convert_to and isinstance(convert_to,str)
+    valid_convert_to = ['seconds', 'minutes']
+    assert convert_to in valid_convert_to and isinstance(convert_to, str)
 
     if convert_to == 'seconds':
         df[time_col] = df[time_col].astype('float')
@@ -625,7 +740,9 @@ def _convert_imp_time_units(df=None, time_col='weight', convert_to='minutes'):
 
     return df
 
-def _stops_in_edge_table_selector(input_stops_df=None, input_stop_times_df=None):
+
+def _stops_in_edge_table_selector(input_stops_df=None,
+                                  input_stop_times_df=None):
     """
     Select stops that are active during the day and time period specified
 
@@ -644,14 +761,24 @@ def _stops_in_edge_table_selector(input_stops_df=None, input_stop_times_df=None)
     start_time = time.time()
 
     # add unique stop id
-    input_stops_df['unique_stop_id'] = input_stops_df[['stop_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
+    input_stops_df['unique_stop_id'] = input_stops_df[
+        ['stop_id', 'unique_agency_id']].apply(
+        lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
 
-    #Select stop ids that match stop ids in the subset stop time data that match day and time selection
-    selected_stops_df = input_stops_df.loc[input_stops_df['unique_stop_id'].isin(input_stop_times_df['unique_stop_id'])]
+    # Select stop ids that match stop ids in the subset stop time data that
+    # match day and time selection
+    selected_stops_df = input_stops_df.loc[
+        input_stops_df['unique_stop_id'].isin(
+            input_stop_times_df['unique_stop_id'])]
 
-    log('{:,} of {:,} records selected from stops. Took {:,.2f} seconds'.format(len(selected_stops_df),len(input_stops_df),time.time()-start_time))
+    log(
+        '{:,} of {:,} records selected from stops. Took {:,'
+        '.2f} seconds'.format(
+            len(selected_stops_df), len(input_stops_df),
+            time.time() - start_time))
 
     return selected_stops_df
+
 
 def _format_transit_net_nodes(df=None):
     """
@@ -671,7 +798,8 @@ def _format_transit_net_nodes(df=None):
 
     # add unique stop id
     if 'unique_stop_id' not in df.columns:
-        df['unique_stop_id'] = df[['stop_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
+        df['unique_stop_id'] = df[['stop_id', 'unique_agency_id']].apply(
+            lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
 
     final_node_df = pd.DataFrame()
     final_node_df['node_id'] = df['unique_stop_id']
@@ -679,20 +807,25 @@ def _format_transit_net_nodes(df=None):
     final_node_df['y'] = df['stop_lat']
 
     # keep useful info from stops table
-    col_list = ['unique_agency_id','route_type','stop_id','stop_name']
+    col_list = ['unique_agency_id', 'route_type', 'stop_id', 'stop_name']
     # if these optional cols exist then keep those that do
-    optional_gtfs_cols = ['parent_station', 'stop_code', 'wheelchair_boarding', 'zone_id','location_type']
+    optional_gtfs_cols = ['parent_station', 'stop_code', 'wheelchair_boarding',
+                          'zone_id', 'location_type']
     for item in optional_gtfs_cols:
-       if item in df.columns:
+        if item in df.columns:
             col_list.append(item)
 
     final_node_df = pd.concat([final_node_df, df[col_list]], axis=1)
     # set node index to be unique stop id
     final_node_df = final_node_df.set_index('node_id')
 
-    log('stop time table transformation to Pandana format node table completed. Took {:,.2f} seconds'.format(time.time()-start_time))
+    log(
+        'stop time table transformation to Pandana format node table '
+        'completed. Took {:,.2f} seconds'.format(
+            time.time() - start_time))
 
     return final_node_df
+
 
 def _route_type_to_edge(transit_edge_df=None, stop_time_df=None):
     """
@@ -713,17 +846,30 @@ def _route_type_to_edge(transit_edge_df=None, stop_time_df=None):
     start_time = time.time()
 
     # create unique trip ids
-    stop_time_df['unique_trip_id'] = stop_time_df[['trip_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
+    stop_time_df['unique_trip_id'] = stop_time_df[
+        ['trip_id', 'unique_agency_id']].apply(
+        lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
 
-    #join route_id to the edge table
-    merged_df = pd.merge(transit_edge_df, stop_time_df[['unique_trip_id','route_type']], how='left', on='unique_trip_id', sort=False, copy=False)
-    merged_df.drop_duplicates(subset='unique_trip_id',keep='first',inplace=True)#need to get unique records here to have a one to one join - this serves as the look up table
-    #join the look up table created above to the table of interest
-    transit_edge_df_w_routetype = pd.merge(transit_edge_df, merged_df[['route_type','unique_trip_id']], how='left', on='unique_trip_id', sort=False, copy=False)
+    # join route_id to the edge table
+    merged_df = pd.merge(transit_edge_df,
+                         stop_time_df[['unique_trip_id', 'route_type']],
+                         how='left', on='unique_trip_id', sort=False,
+                         copy=False)
+    merged_df.drop_duplicates(subset='unique_trip_id', keep='first', inplace
+    =True)  # need to get unique records here to have a one to one join -
+    # this serves as the look up table
+    # join the look up table created above to the table of interest
+    transit_edge_df_w_routetype = pd.merge(transit_edge_df, merged_df[
+        ['route_type', 'unique_trip_id']], how='left', on='unique_trip_id',
+                                           sort=False, copy=False)
 
-    log('route type successfully joined to transit edges. Took {:,.2f} seconds'.format(time.time()-start_time))
+    log(
+        'route type successfully joined to transit edges. Took {:,'
+        '.2f} seconds'.format(
+            time.time() - start_time))
 
     return transit_edge_df_w_routetype
+
 
 def _route_id_to_edge(transit_edge_df=None, trips_df=None):
     """
@@ -744,18 +890,27 @@ def _route_id_to_edge(transit_edge_df=None, trips_df=None):
     start_time = time.time()
 
     if 'unique_route_id' not in transit_edge_df.columns:
-
         # create unique trip and route ids
-        trips_df['unique_trip_id'] = trips_df[['trip_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
-        trips_df['unique_route_id'] = trips_df[['route_id','unique_agency_id']].apply(lambda x : '{}_{}'.format(x[0],x[1]), axis=1)
+        trips_df['unique_trip_id'] = trips_df[
+            ['trip_id', 'unique_agency_id']].apply(
+            lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
+        trips_df['unique_route_id'] = trips_df[
+            ['route_id', 'unique_agency_id']].apply(
+            lambda x: '{}_{}'.format(x[0], x[1]), axis=1)
 
-        transit_edge_df_with_routes = pd.merge(transit_edge_df, trips_df[['unique_trip_id','unique_route_id']],
-                                                how='left',
-                                                on = 'unique_trip_id', sort=False, copy=False)
+        transit_edge_df_with_routes = pd.merge(transit_edge_df, trips_df[
+            ['unique_trip_id', 'unique_route_id']],
+                                               how='left',
+                                               on='unique_trip_id', sort=False,
+                                               copy=False)
 
-    log('route id successfully joined to transit edges. Took {:,.2f} seconds'.format(time.time()-start_time))
+    log(
+        'route id successfully joined to transit edges. Took {:,'
+        '.2f} seconds'.format(
+            time.time() - start_time))
 
     return transit_edge_df_with_routes
+
 
 def edge_impedance_by_route_type(transit_edge_df=None,
                                  street_level_rail=None,
@@ -794,54 +949,111 @@ def edge_impedance_by_route_type(transit_edge_df=None,
     ua_network.transit_edges : pandas.DataFrame
 
     """
-    assert 'route_type' in transit_edge_df.columns, 'No route_type column was found in dataframe'
+    assert 'route_type' in transit_edge_df.columns, 'No route_type column ' \
+                                                    'was found in dataframe'
 
     # check count of records for each route type
-    route_type_desc = {0:'Street Level Rail: Tram Streetcar Light rail',1:'Underground rail: Subway or Metro',
-                       2:'Rail: intercity or long-distance ',3:'Bus',4:'Ferry',5:'Cable Car',
-                       6:'Gondola or Suspended cable car',7:'Steep incline: Funicular'}
+    route_type_desc = {0: 'Street Level Rail: Tram Streetcar Light rail',
+                       1: 'Underground rail: Subway or Metro',
+                       2: 'Rail: intercity or long-distance ', 3: 'Bus',
+                       4: 'Ferry', 5: 'Cable Car',
+                       6: 'Gondola or Suspended cable car',
+                       7: 'Steep incline: Funicular'}
     log('Route type distribution as percentage of '
-        'transit mode: {:.2f}'.format(transit_edge_df['route_type'].map(route_type_desc.get).value_counts(normalize=True,dropna=False)*100))
+        'transit mode: {:.2f}'.format(
+        transit_edge_df['route_type'].map(route_type_desc.get).value_counts(
+            normalize=True, dropna=False) * 100))
 
-    var_list = [street_level_rail,underground_rail,intercity_rail,bus,ferry,cable_car,gondola,funicular]
+    var_list = [street_level_rail, underground_rail, intercity_rail, bus,
+                ferry, cable_car, gondola, funicular]
 
     for var in var_list:
         if var is not None:
-            assert isinstance(var,float), 'One or more variables are not float'
+            assert isinstance(var,
+                              float), 'One or more variables are not float'
 
-    travel_time_col_name='weight'
+    travel_time_col_name = 'weight'
     travel_time_col = transit_edge_df[travel_time_col_name]
 
-    if street_level_rail is not None and len(transit_edge_df[transit_edge_df['route_type'] == 0]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==0] = travel_time_col+(travel_time_col*street_level_rail)
-        log('Adjusted Street Level Rail transit edge impedance based on mode type penalty coefficient: {}'.format(street_level_rail))
-    if underground_rail is not None and len(transit_edge_df[transit_edge_df['route_type'] == 1]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==1] = travel_time_col+(travel_time_col*underground_rail)
-        log('Adjusted Underground rail transit edge impedance based on mode type penalty coefficient: {}'.format(underground_rail))
-    if intercity_rail is not None and len(transit_edge_df[transit_edge_df['route_type'] == 2]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==2] = travel_time_col+(travel_time_col*intercity_rail)
-        log('Adjusted Rail transit edge impedance based on mode type penalty coefficient: {}'.format(intercity_rail))
-    if bus is not None and len(transit_edge_df[transit_edge_df['route_type'] == 3]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==3] = travel_time_col+(travel_time_col*bus)
-        log('Adjusted Bus transit edge impedance based on mode type penalty coefficient: {}'.format(bus))
-    if ferry is not None and len(transit_edge_df[transit_edge_df['route_type'] == 4]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==4] = travel_time_col+(travel_time_col*ferry)
-        log('Adjusted Ferry transit edge impedance based on mode type penalty coefficient: {}'.format(ferry))
-    if cable_car is not None and len(transit_edge_df[transit_edge_df['route_type'] == 5]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==5] = travel_time_col+(travel_time_col*cable_car)
-        log('Adjusted Cable Car transit edge impedance based on mode type penalty coefficient: {}'.format(cable_car))
-    if gondola is not None and len(transit_edge_df[transit_edge_df['route_type'] == 6]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==6] = travel_time_col+(travel_time_col*gondola)
-        log('Adjusted Gondola or Suspended cable car transit edge impedance based on mode type penalty coefficient: {}'.format(gondola))
-    if funicular is not None and len(transit_edge_df[transit_edge_df['route_type'] == 7]) > 0:
-        transit_edge_df[travel_time_col_name][transit_edge_df['route_type']==7] = travel_time_col+(travel_time_col*funicular)
-        log('Adjusted Funicular transit edge impedance based on mode type penalty coefficient: {}'.format(funicular))
+    if street_level_rail is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 0]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 0] = travel_time_col + (
+        travel_time_col * street_level_rail)
+        log(
+            'Adjusted Street Level Rail transit edge impedance based on mode'
+            ' type penalty coefficient: {}'.format(
+                street_level_rail))
+    if underground_rail is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 1]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 1] = travel_time_col + (
+        travel_time_col * underground_rail)
+        log(
+            'Adjusted Underground rail transit edge impedance based on mode '
+            'type penalty coefficient: {}'.format(
+                underground_rail))
+    if intercity_rail is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 2]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 2] = travel_time_col + (
+        travel_time_col * intercity_rail)
+        log(
+            'Adjusted Rail transit edge impedance based on mode type penalty '
+            'coefficient: {}'.format(
+                intercity_rail))
+    if bus is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 3]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 3] = travel_time_col + (
+        travel_time_col * bus)
+        log(
+            'Adjusted Bus transit edge impedance based on mode type penalty '
+            'coefficient: {}'.format(
+                bus))
+    if ferry is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 4]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 4] = travel_time_col + (
+        travel_time_col * ferry)
+        log(
+            'Adjusted Ferry transit edge impedance based on mode type '
+            'penalty coefficient: {}'.format(
+                ferry))
+    if cable_car is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 5]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 5] = travel_time_col + (
+        travel_time_col * cable_car)
+        log(
+            'Adjusted Cable Car transit edge impedance based on mode type '
+            'penalty coefficient: {}'.format(
+                cable_car))
+    if gondola is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 6]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 6] = travel_time_col + (
+        travel_time_col * gondola)
+        log(
+            'Adjusted Gondola or Suspended cable car transit edge impedance '
+            'based on mode type penalty coefficient: {}'.format(
+                gondola))
+    if funicular is not None and len(
+            transit_edge_df[transit_edge_df['route_type'] == 7]) > 0:
+        transit_edge_df[travel_time_col_name][
+            transit_edge_df['route_type'] == 7] = travel_time_col + (
+        travel_time_col * funicular)
+        log(
+            'Adjusted Funicular transit edge impedance based on mode type '
+            'penalty coefficient: {}'.format(
+                funicular))
 
     ua_network.transit_edges = transit_edge_df
 
     log('Transit edge impedance mode type penalty calculation complete')
 
     return ua_network
+
 
 def save_processed_gtfs_data(gtfsfeeds_dfs=None,
                              dir=config.settings.data_folder,
@@ -869,30 +1081,39 @@ def save_processed_gtfs_data(gtfsfeeds_dfs=None,
            or gtfsfeeds_dfs.stop_times.empty == False \
            or gtfsfeeds_dfs.calendar.empty == False \
            or gtfsfeeds_dfs.stop_times_int.empty == False, 'gtfsfeeds_dfs is ' \
-                                                           'missing one of the required dataframes.'
+                                                           '' \
+                                                           'missing one of ' \
+                                                           'the required ' \
+                                                           'dataframes.'
 
-    df_to_hdf5(data=gtfsfeeds_dfs.stops,key='stops',overwrite_key=False,
-               dir=dir,filename=filename,overwrite_hdf5=False)
-    df_to_hdf5(data=gtfsfeeds_dfs.routes,key='routes',overwrite_key=False,
-               dir=dir,filename=filename,overwrite_hdf5=False)
-    df_to_hdf5(data=gtfsfeeds_dfs.trips,key='trips',overwrite_key=False,
-               dir=dir,filename=filename,overwrite_hdf5=False)
-    df_to_hdf5(data=gtfsfeeds_dfs.stop_times,key='stop_times',
-               overwrite_key=False,dir=dir,filename=filename,overwrite_hdf5=False)
-    df_to_hdf5(data=gtfsfeeds_dfs.calendar,key='calendar',
-               overwrite_key=False,dir=dir,filename=filename,overwrite_hdf5=False)
-    df_to_hdf5(data=gtfsfeeds_dfs.stop_times_int,key='stop_times_int',
-               overwrite_key=False,dir=dir,filename=filename,overwrite_hdf5=False)
+    df_to_hdf5(data=gtfsfeeds_dfs.stops, key='stops', overwrite_key=False,
+               dir=dir, filename=filename, overwrite_hdf5=False)
+    df_to_hdf5(data=gtfsfeeds_dfs.routes, key='routes', overwrite_key=False,
+               dir=dir, filename=filename, overwrite_hdf5=False)
+    df_to_hdf5(data=gtfsfeeds_dfs.trips, key='trips', overwrite_key=False,
+               dir=dir, filename=filename, overwrite_hdf5=False)
+    df_to_hdf5(data=gtfsfeeds_dfs.stop_times, key='stop_times',
+               overwrite_key=False, dir=dir, filename=filename,
+               overwrite_hdf5=False)
+    df_to_hdf5(data=gtfsfeeds_dfs.calendar, key='calendar',
+               overwrite_key=False, dir=dir, filename=filename,
+               overwrite_hdf5=False)
+    df_to_hdf5(data=gtfsfeeds_dfs.stop_times_int, key='stop_times_int',
+               overwrite_key=False, dir=dir, filename=filename,
+               overwrite_hdf5=False)
 
     if gtfsfeeds_dfs.headways.empty == False:
-        df_to_hdf5(data=gtfsfeeds_dfs.headways,key='headways',
-                   overwrite_key=False,dir=dir,filename=filename,overwrite_hdf5=False)
+        df_to_hdf5(data=gtfsfeeds_dfs.headways, key='headways',
+                   overwrite_key=False, dir=dir, filename=filename,
+                   overwrite_hdf5=False)
 
     if gtfsfeeds_dfs.calendar_dates.empty == False:
-        df_to_hdf5(data=gtfsfeeds_dfs.calendar_dates,key='calendar_dates',
-                   overwrite_key=False,dir=dir,filename=filename,overwrite_hdf5=False)
+        df_to_hdf5(data=gtfsfeeds_dfs.calendar_dates, key='calendar_dates',
+                   overwrite_key=False, dir=dir, filename=filename,
+                   overwrite_hdf5=False)
 
-def load_processed_gtfs_data(dir=config.settings.data_folder,filename=None):
+
+def load_processed_gtfs_data(dir=config.settings.data_folder, filename=None):
     """
     Read data from a hdf5 file to a gtfsfeeds_dfs object
 
@@ -907,27 +1128,30 @@ def load_processed_gtfs_data(dir=config.settings.data_folder,filename=None):
     -------
     gtfsfeeds_dfs : object
     """
-    gtfsfeeds_dfs.stops = hdf5_to_df(dir=dir,filename=filename,key='stops')
-    gtfsfeeds_dfs.routes = hdf5_to_df(dir=dir,filename=filename,key='routes')
-    gtfsfeeds_dfs.trips = hdf5_to_df(dir=dir,filename=filename,key='trips')
-    gtfsfeeds_dfs.stop_times = hdf5_to_df(dir=dir,filename=filename,
+    gtfsfeeds_dfs.stops = hdf5_to_df(dir=dir, filename=filename, key='stops')
+    gtfsfeeds_dfs.routes = hdf5_to_df(dir=dir, filename=filename, key='routes')
+    gtfsfeeds_dfs.trips = hdf5_to_df(dir=dir, filename=filename, key='trips')
+    gtfsfeeds_dfs.stop_times = hdf5_to_df(dir=dir, filename=filename,
                                           key='stop_times')
-    gtfsfeeds_dfs.calendar = hdf5_to_df(dir=dir,filename=filename,
+    gtfsfeeds_dfs.calendar = hdf5_to_df(dir=dir, filename=filename,
                                         key='calendar')
-    gtfsfeeds_dfs.stop_times_int = hdf5_to_df(dir=dir,filename=filename,
+    gtfsfeeds_dfs.stop_times_int = hdf5_to_df(dir=dir, filename=filename,
                                               key='stop_times_int')
 
-    hdf5_load_path = '{}/{}'.format(dir,filename)
+    hdf5_load_path = '{}/{}'.format(dir, filename)
     with pd.HDFStore(hdf5_load_path) as store:
 
-            if 'headways' in store.keys():
-                gtfsfeeds_dfs.headways = hdf5_to_df(dir=dir,
-                                                    filename=filename,key='headways')
-            if 'calendar_dates' in store.keys():
-                gtfsfeeds_dfs.calendar_dates = hdf5_to_df(dir=dir,
-                                                          filename=filename,key='calendar_dates')
+        if 'headways' in store.keys():
+            gtfsfeeds_dfs.headways = hdf5_to_df(dir=dir,
+                                                filename=filename,
+                                                key='headways')
+        if 'calendar_dates' in store.keys():
+            gtfsfeeds_dfs.calendar_dates = hdf5_to_df(dir=dir,
+                                                      filename=filename,
+                                                      key='calendar_dates')
 
     return gtfsfeeds_dfs
+
 
 def _check_if_index_name_in_cols(df):
     """

--- a/urbanaccess/gtfs/utils_format.py
+++ b/urbanaccess/gtfs/utils_format.py
@@ -238,6 +238,9 @@ def _calendar_agencyid(calendar_df=None, routes_df=None, trips_df=None, agency_d
     """
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
     tmp2 = pd.merge(trips_df, tmp1, how='left', on='route_id', sort=False, copy=False)
+    # do another merge to account for service ids that may not be utilized
+    # across all GTFS files for accounting purposes so we keep those that
+    # dont show up after merge
     merged_df = pd.merge(calendar_df[['service_id']], tmp2, how='left', on='service_id', sort=False, copy=False)
     merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='service_id', keep='first', inplace=True)
@@ -297,6 +300,9 @@ def _stops_agencyid(stops_df=None, trips_df=None, routes_df=None, stop_times_df=
     tmp1 = pd.merge(routes_df, agency_df, how='left', on='agency_id', sort=False, copy=False)
     tmp2 = pd.merge(trips_df, tmp1, how='left', on='route_id', sort=False, copy=False)
     tmp3 = pd.merge(stop_times_df, tmp2, how='left', on='trip_id', sort=False, copy=False)
+    # do another merge to account for stops that may not be utilized across all
+    # GTFS files for accounting purposes so we keep those that dont show up
+    # after merge
     merged_df = pd.merge(stops_df[['stop_id']], tmp3, how='left', on='stop_id', sort=False, copy=False)
     merged_df['unique_agency_id'] = _generate_unique_agency_id(merged_df, 'agency_name')
     merged_df.drop_duplicates(subset='stop_id', keep='first', inplace=True)

--- a/urbanaccess/gtfs/utils_validation.py
+++ b/urbanaccess/gtfs/utils_validation.py
@@ -64,6 +64,7 @@ def _boundingbox_check(df=None, feed_folder=None, lat_min=None, lng_min=None, la
             log('Removed identified stops that are outside of bounding box.')
             return df_subset
     else:
+        log('No GTFS feed stops were found to be outside the bounding box coordinates')
         return df
 
 def _checkcoordinates(df=None, feed_folder=None):

--- a/urbanaccess/network.py
+++ b/urbanaccess/network.py
@@ -356,7 +356,13 @@ def _format_pandana_edges_nodes(edge_df, node_df):
     # turn mixed dtype cols into all same format
     col_list = edge_df_wnumericid.select_dtypes(include=['object']).columns
     for col in col_list:
-        edge_df_wnumericid[col] = edge_df_wnumericid[col].astype(str)
+        try:
+            edge_df_wnumericid[col] = edge_df_wnumericid[col].astype(str)
+        # deal with edge cases where typically the name of a street is not
+        # in a uniform string encoding such as names with accents
+        except UnicodeEncodeError:
+            log('Fixed unicode error in {} column'.format(col))
+            edge_df_wnumericid[col] = edge_df_wnumericid[col].str.encode('utf-8')
 
     node_df.set_index('id_int',drop=True,inplace=True)
     # turn mixed dtype col into all same format

--- a/urbanaccess/tests/test_gtfs_network.py
+++ b/urbanaccess/tests/test_gtfs_network.py
@@ -82,7 +82,7 @@ def stop_times_interpolated():
 
 
 def test_interpolator(stop_times, calendar):
-    df = network._interpolatestoptimes(stop_times, calendar, day='monday')
+    df = network._interpolate_stop_times(stop_times, calendar, day='monday')
 
     # unique_trip_id should be generated
     assert df.loc[1, 'unique_trip_id'] == 'a_citytrains'
@@ -121,7 +121,7 @@ def test_skip_interpolator(stop_times, calendar):
 
     stop_times['departure_time_sec'] = series
 
-    df = network._interpolatestoptimes(stop_times, calendar, day='monday')
+    df = network._interpolate_stop_times(stop_times, calendar, day='monday')
 
     # everything should be the same,
     # with one row dropped for calendar day filter


### PR DESCRIPTION
Handles cases where returned OSM street edge names have strings with accents and for cases where service_ids do not exist in the calendar and instead exist in calendar_dates this allows for the use of service_ids that are inside the calendar_dates file to supplement those in calendar.