### PR TITLE
Updates for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 - '2.7'
 - '3.5'
 - '3.6'
-- '3.7'
 
 install:
 - wget http://bit.ly/miniconda -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ python:
 - '3.7'
 
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
+- wget http://bit.ly/miniconda -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"
 - hash -r
@@ -19,7 +17,7 @@ install:
 - conda config --add channels udst
 - conda config --add channels conda-forge
 - |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy=1.11 pandas pytest ipython-notebook pycodestyle matplotlib scikit-learn pyyaml basemap basemap-data-hires
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy pandas pytest jupyter pycodestyle matplotlib scikit-learn pyyaml basemap basemap-data-hires
 - source activate test-environment
 - conda list
 - pip install pandana==0.3.0 geopy osmnet

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 sudo: false
 python:
 - '2.7'
+- '3.5'
+- '3.6'
+- '3.7'
 
 install:
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh

--- a/README.rst
+++ b/README.rst
@@ -46,16 +46,21 @@ Let us know what you are working on or if you think you have a great use
 case by tweeting us at ``@urbansim`` or post on the UrbanSim
 `forum <http://discussion.urbansim.com/>`__.
 
+Citation and academic literature
+--------------------------------
+
+To cite this tool and for a complete description of the UrbanAccess methodology see the paper below:
+
+`Samuel D. Blanchard and Paul Waddell. 2017. "UrbanAccess: Generalized Methodology for Measuring Regional Accessibility with an Integrated Pedestrian and Transit Network." Transportation Research Record: Journal of the Transportation Research Board. No. 2653. pp. 35–44. <http://trrjournalonline.trb.org/doi/pdf/10.3141/2653-05>`__
+
+For other related literature see `here <https://udst.github.io/urbanaccess/introduction.html#citation-and-academic-literature>`__.
+
 Current status
 --------------
-
-UrbanAccess is currently in a alpha release and only compatible with
-Python 2.x. Further code refinements are expected.
 
 *Forthcoming improvements:*
 
 - Unit tests
-- Python 3
 
 Reporting bugs
 --------------
@@ -77,7 +82,9 @@ Install the latest release
 
 conda
 ~~~~~~
-conda installation is forthcoming.
+UrbanAccess is available on conda and can be installed with::
+
+    conda install -c udst urbanaccess
 
 pip
 ~~~~~~
@@ -88,7 +95,7 @@ UrbanAccess is available on PyPI and can be installed with::
 Development Installation
 ------------------------
 
-UrbanAccess is currently in a alpha release and further code refinements are expected. As such, it is suggested to install using the ``develop`` command rather than ``install``. Make sure you are using the latest version of the code base by using git's ``git pull`` inside the cloned repository.
+Developers contributing code can install using the ``develop`` command rather than ``install``. Make sure you are using the latest version of the codebase by using git's ``git pull`` inside the cloned repository.
 
 To install UrbanAccess follow these steps:
 
@@ -116,15 +123,6 @@ types <https://developers.google.com/transit/gtfs/>`__ required to use
 UrbanAccess are: ``stop_times``, ``stops``, ``routes``, ``calendar``,
 and ``trips`` however if there is no ``calendar``, ``calendar_dates``
 can be used as a replacement.
-
-Citation and academic literature
---------------------------------
-
-To cite this tool and for a complete description of the UrbanAccess methodology see the paper below:
-
-`Samuel D. Blanchard and Paul Waddell. 2017. "UrbanAccess: Generalized Methodology for Measuring Regional Accessibility with an Integrated Pedestrian and Transit Network." Transportation Research Record: Journal of the Transportation Research Board. No. 2653. pp. 35–44. <http://trrjournalonline.trb.org/doi/pdf/10.3141/2653-05>`__
-
-For other related literature see `here <https://udst.github.io/urbanaccess/introduction.html#citation-and-academic-literature>`__.
 
 Related UDST libraries
 ----------------------

--- a/demo/simple_example.ipynb
+++ b/demo/simple_example.ipynb
@@ -13,15 +13,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "** Author:**  UrbanSim\n",
+    "**Author:**  UrbanSim\n",
     "\n",
     "This notebook provides a brief overview of the main functionality of UrbanAccess with examples using AC Transit and BART GTFS data and OpenStreetMap (OSM) pedestrian network data to create an integrated transit and pedestrian network for Oakland, CA for use in Pandana network accessibility queries.\n",
     "\n",
-    "** UrbanAccess on UDST:**  https://github.com/UDST/urbanaccess\n",
+    "**UrbanAccess on UDST:**  https://github.com/UDST/urbanaccess\n",
     "\n",
-    "** UrbanAccess documentation:**  https://udst.github.io/urbanaccess/index.html\n",
+    "**UrbanAccess documentation:**  https://udst.github.io/urbanaccess/index.html\n",
     "\n",
-    "** UrbanAccess citation:**  \n",
+    "**UrbanAccess citation:**  \n",
     "\n",
     "`Samuel D. Blanchard and Paul Waddell, 2017, \"UrbanAccess: Generalized Methodology for Measuring Regional Accessibility with an Integrated Pedestrian and Transit Network\" Transportation Research Record: Journal of the Transportation Research Board, 2653: 35–44.`\n",
     "\n",
@@ -1230,7 +1230,7 @@
     "blocks = pd.read_hdf('bay_area_demo_data.h5','blocks')\n",
     "# remove blocks that contain all water\n",
     "blocks = blocks[blocks['square_meters_land'] != 0]\n",
-    "print 'Total number of blocks: {:,}'.format(len(blocks))\n",
+    "print('Total number of blocks: {:,}'.format(len(blocks)))\n",
     "blocks.head()"
    ]
   },
@@ -1252,7 +1252,7 @@
     "lng_max, lat_min, lng_min, lat_max = bbox\n",
     "outside_bbox = blocks.loc[~(((lng_max < blocks[\"x\"]) & (blocks[\"x\"] < lng_min)) & ((lat_min < blocks[\"y\"]) & (blocks[\"y\"] < lat_max)))]\n",
     "blocks_subset = blocks.drop(outside_bbox.index)\n",
-    "print 'Total number of subset blocks: {:,}'.format(len(blocks_subset))"
+    "print('Total number of subset blocks: {:,}'.format(len(blocks_subset)))"
    ]
   },
   {
@@ -1393,9 +1393,9 @@
    },
    "outputs": [],
    "source": [
-    "print jobs_45.head()\n",
-    "print jobs_30.head()\n",
-    "print jobs_15.head()"
+    "print(jobs_45.head())\n",
+    "print(jobs_30.head())\n",
+    "print(jobs_15.head())"
    ]
   },
   {
@@ -1416,7 +1416,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -1441,7 +1441,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1465,7 +1465,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1477,13 +1477,49 @@
     "                    plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
     "print('Took {:,.2f} seconds'.format(time.time() - s_time))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda env:urbanaccess-py2]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-env-urbanaccess-py2-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1495,7 +1531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/demo/simple_example.ipynb
+++ b/demo/simple_example.ipynb
@@ -1421,13 +1421,13 @@
    },
    "outputs": [],
    "source": [
-    "s_time = time.time()\n",
-    "transit_ped_net.plot(jobs_15, \n",
-    "                    plot_type='scatter',\n",
-    "                    fig_kwargs={'figsize':[20,20]},\n",
-    "                    bmap_kwargs={'epsg':'26943','resolution':'h'},\n",
-    "                    plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
-    "print('Took {:,.2f} seconds'.format(time.time() - s_time))"
+    "# s_time = time.time()\n",
+    "# transit_ped_net.plot(jobs_15, \n",
+    "#                     plot_type='scatter',\n",
+    "#                     fig_kwargs={'figsize':[20,20]},\n",
+    "#                     bmap_kwargs={'epsg':'26943','resolution':'h'},\n",
+    "#                     plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
+    "# print('Took {:,.2f} seconds'.format(time.time() - s_time))"
    ]
   },
   {
@@ -1445,13 +1445,13 @@
    },
    "outputs": [],
    "source": [
-    "s_time = time.time()\n",
-    "transit_ped_net.plot(jobs_30, \n",
-    "                    plot_type='scatter',\n",
-    "                    fig_kwargs={'figsize':[20,20]},\n",
-    "                    bmap_kwargs={'epsg':'26943','resolution':'h'},\n",
-    "                    plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
-    "print('Took {:,.2f} seconds'.format(time.time() - s_time))"
+    "# s_time = time.time()\n",
+    "# transit_ped_net.plot(jobs_30, \n",
+    "#                     plot_type='scatter',\n",
+    "#                     fig_kwargs={'figsize':[20,20]},\n",
+    "#                     bmap_kwargs={'epsg':'26943','resolution':'h'},\n",
+    "#                     plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
+    "# print('Took {:,.2f} seconds'.format(time.time() - s_time))"
    ]
   },
   {
@@ -1469,13 +1469,13 @@
    },
    "outputs": [],
    "source": [
-    "s_time = time.time()\n",
-    "transit_ped_net.plot(jobs_45, \n",
-    "                    plot_type='scatter',\n",
-    "                    fig_kwargs={'figsize':[20,20]},\n",
-    "                    bmap_kwargs={'epsg':'26943','resolution':'h'},\n",
-    "                    plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
-    "print('Took {:,.2f} seconds'.format(time.time() - s_time))"
+    "# s_time = time.time()\n",
+    "# transit_ped_net.plot(jobs_45, \n",
+    "#                     plot_type='scatter',\n",
+    "#                     fig_kwargs={'figsize':[20,20]},\n",
+    "#                     bmap_kwargs={'epsg':'26943','resolution':'h'},\n",
+    "#                     plot_kwargs={'cmap':'gist_heat_r','s':4,'edgecolor':'none'})\n",
+    "# print('Took {:,.2f} seconds'.format(time.time() - s_time))"
    ]
   },
   {

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,9 +7,10 @@ Dependencies
 ------------
 
 * requests >= 2.9.1
+* six >= 1.11
 * pandas >= 0.17.0
 * numpy >= 1.11
-* osmnet >= 0.1a
+* osmnet >= 0.1.4
 * pandana >= 0.2.0
 * matplotlib >= 2.0
 * geopy >= 1.11.0
@@ -24,19 +25,18 @@ Dependencies can be installed through the ``conda-forge`` and ``udst`` channels.
 Current status
 --------------
 
-UrbanAccess is currently in a alpha release and only compatible with Python 2.x. Further code refinements are expected.
-
 *Forthcoming improvements:*
 
 * Unit tests
-* Python 3
 
 Install the latest release
 --------------------------
 
 conda
 ~~~~~~
-conda installation is forthcoming.
+UrbanAccess is available on conda and can be installed with::
+
+    conda install -c udst urbanaccess
 
 pip
 ~~~~~~
@@ -47,7 +47,7 @@ UrbanAccess is available on PyPI and can be installed with::
 Development Installation
 ------------------------
 
-UrbanAccess is currently in a alpha release and further code refinements are expected. As such, it is suggested to install using the ``develop`` command rather than ``install``. Make sure you are using the latest version of the code base by using git's ``git pull`` inside the cloned repository.
+Developers contributing code can install using the ``develop`` command rather than ``install``. Make sure you are using the latest version of the codebase by using git's ``git pull`` inside the cloned repository.
 
 To install UrbanAccess follow these steps:
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,12 @@ setup(
     author='UrbanSim Inc. and Samuel D. Blanchard',
     url='https://github.com/UDST/urbanaccess',
     classifiers=[
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: GNU Affero General Public License v3'
     ],

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,16 @@ setup(
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
         'requests >= 2.9.1',
+        'six >= 1.11',
         'pandas >= 0.17.0',
         'numpy >= 1.11',
         'osmnet >= 0.1.4',
         'pandana >= 0.2.0',
         'matplotlib >= 2.0',
+        'basemap >= 1.0',
+        'basemap-data-hires > 1.0',
         'geopy >= 1.11.0',
         'pyyaml >= 3.11',
-        'scikit-learn >= 0.17.1'
+        'scikit-learn >= 0.17.1',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ description = 'A tool for creating GTFS transit and OSM pedestrian networks ' \
 
 setup(
     name='urbanaccess',
-    version='0.1.0',
+    version='0.2.dev1',
     license='AGPL',
     description=description,
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,8 @@ setup(
         'osmnet >= 0.1.4',
         'pandana >= 0.2.0',
         'matplotlib >= 2.0',
-        'basemap >= 1.0',
-        'basemap-data-hires > 1.0',
         'geopy >= 1.11.0',
         'pyyaml >= 3.11',
-        'scikit-learn >= 0.17.1',
+        'scikit-learn >= 0.17.1'
     ]
 )

--- a/urbanaccess/__init__.py
+++ b/urbanaccess/__init__.py
@@ -9,6 +9,6 @@ from .utils import *
 from .gtfsfeeds import *
 from .plot import *
 
-__version__ = "0.1.0"
+__version__ = "0.2.dev1"
 
 version = __version__

--- a/urbanaccess/gtfs/load.py
+++ b/urbanaccess/gtfs/load.py
@@ -43,7 +43,7 @@ def _txt_encoder_check(gtfsfiles_to_use,
                            'gtfsfeed_text')):
     """
     Standardize all text files inside a GTFS feed for encoding problems.
-    Not yet updated for Python 3.
+    Has not been updated for Python 3.
 
     Parameters
     ----------

--- a/urbanaccess/gtfs/load.py
+++ b/urbanaccess/gtfs/load.py
@@ -31,59 +31,59 @@ def _standardize_txt(csv_rootpath=os.path.join(config.settings.data_folder,
                         'stop_times.txt', 'calendar.txt',
                         'agency.txt', 'calendar_dates.txt']
 
-    _txt_encoder_check(gtfsfiles_to_use, csv_rootpath)
+#     _txt_encoder_check(gtfsfiles_to_use, csv_rootpath)
     _txt_header_whitespace_check(gtfsfiles_to_use, csv_rootpath)
 
 
-def _txt_encoder_check(gtfsfiles_to_use,
-                       csv_rootpath=os.path.join(
-                           config.settings.data_folder,
-                           'gtfsfeed_text')):
-    """
-    Standardize all text files inside a GTFS feed for encoding problems
-
-    Parameters
-    ----------
-    gtfsfiles_to_use : list
-        list of gtfs feed txt files to utilize
-    csv_rootpath : str, optional
-        root path where all gtfs feeds that make up a contiguous metropolitan
-        area are stored
-
-    Returns
-    -------
-    None
-    """
-    # UnicodeDecodeError
-    start_time = time.time()
-
-    folderlist = [foldername for foldername in os.listdir(csv_rootpath) if
-                  os.path.isdir(os.path.join(csv_rootpath, foldername))]
-
-    if not folderlist:
-        folderlist = [csv_rootpath]
-
-    for folder in folderlist:
-        textfilelist = [textfilename for textfilename in
-                        os.listdir(os.path.join(csv_rootpath, folder)) if
-                        textfilename.endswith(".txt")]
-
-        for textfile in textfilelist:
-            if textfile in gtfsfiles_to_use:
-                # Read from file
-                file_open = open(os.path.join(csv_rootpath, folder, textfile))
-                raw = file_open.read()
-                file_open.close()
-                if raw.startswith(codecs.BOM_UTF8):
-                    raw = raw.replace(codecs.BOM_UTF8, '', 1)
-                    # Write to file
-                    file_open = open(
-                        os.path.join(csv_rootpath, folder, textfile), 'w')
-                    file_open.write(raw)
-                    file_open.close()
-
-    log('GTFS text file encoding check completed. Took {:,.2f} seconds'.format(
-        time.time() - start_time))
+# def _txt_encoder_check(gtfsfiles_to_use,
+#                        csv_rootpath=os.path.join(
+#                            config.settings.data_folder,
+#                            'gtfsfeed_text')):
+#     """
+#     Standardize all text files inside a GTFS feed for encoding problems
+# 
+#     Parameters
+#     ----------
+#     gtfsfiles_to_use : list
+#         list of gtfs feed txt files to utilize
+#     csv_rootpath : str, optional
+#         root path where all gtfs feeds that make up a contiguous metropolitan
+#         area are stored
+# 
+#     Returns
+#     -------
+#     None
+#     """
+#     # UnicodeDecodeError
+#     start_time = time.time()
+# 
+#     folderlist = [foldername for foldername in os.listdir(csv_rootpath) if
+#                   os.path.isdir(os.path.join(csv_rootpath, foldername))]
+# 
+#     if not folderlist:
+#         folderlist = [csv_rootpath]
+# 
+#     for folder in folderlist:
+#         textfilelist = [textfilename for textfilename in
+#                         os.listdir(os.path.join(csv_rootpath, folder)) if
+#                         textfilename.endswith(".txt")]
+# 
+#         for textfile in textfilelist:
+#             if textfile in gtfsfiles_to_use:
+#                 # Read from file
+#                 file_open = open(os.path.join(csv_rootpath, folder, textfile))
+#                 raw = file_open.read()
+#                 file_open.close()
+#                 if raw.startswith(codecs.BOM_UTF8):
+#                     raw = raw.replace(codecs.BOM_UTF8, '', 1)
+#                     # Write to file
+#                     file_open = open(
+#                         os.path.join(csv_rootpath, folder, textfile), 'w')
+#                     file_open.write(raw)
+#                     file_open.close()
+# 
+#     log('GTFS text file encoding check completed. Took {:,.2f} seconds'.format(
+#         time.time() - start_time))
 
 
 def _txt_header_whitespace_check(gtfsfiles_to_use,

--- a/urbanaccess/gtfs/load.py
+++ b/urbanaccess/gtfs/load.py
@@ -3,6 +3,7 @@ import codecs
 import re
 import time
 import pandas as pd
+import six
 
 from urbanaccess import config
 from urbanaccess.utils import log
@@ -31,59 +32,61 @@ def _standardize_txt(csv_rootpath=os.path.join(config.settings.data_folder,
                         'stop_times.txt', 'calendar.txt',
                         'agency.txt', 'calendar_dates.txt']
 
-#     _txt_encoder_check(gtfsfiles_to_use, csv_rootpath)
+    if six.PY2:
+        _txt_encoder_check(gtfsfiles_to_use, csv_rootpath)
     _txt_header_whitespace_check(gtfsfiles_to_use, csv_rootpath)
 
 
-# def _txt_encoder_check(gtfsfiles_to_use,
-#                        csv_rootpath=os.path.join(
-#                            config.settings.data_folder,
-#                            'gtfsfeed_text')):
-#     """
-#     Standardize all text files inside a GTFS feed for encoding problems
-# 
-#     Parameters
-#     ----------
-#     gtfsfiles_to_use : list
-#         list of gtfs feed txt files to utilize
-#     csv_rootpath : str, optional
-#         root path where all gtfs feeds that make up a contiguous metropolitan
-#         area are stored
-# 
-#     Returns
-#     -------
-#     None
-#     """
-#     # UnicodeDecodeError
-#     start_time = time.time()
-# 
-#     folderlist = [foldername for foldername in os.listdir(csv_rootpath) if
-#                   os.path.isdir(os.path.join(csv_rootpath, foldername))]
-# 
-#     if not folderlist:
-#         folderlist = [csv_rootpath]
-# 
-#     for folder in folderlist:
-#         textfilelist = [textfilename for textfilename in
-#                         os.listdir(os.path.join(csv_rootpath, folder)) if
-#                         textfilename.endswith(".txt")]
-# 
-#         for textfile in textfilelist:
-#             if textfile in gtfsfiles_to_use:
-#                 # Read from file
-#                 file_open = open(os.path.join(csv_rootpath, folder, textfile))
-#                 raw = file_open.read()
-#                 file_open.close()
-#                 if raw.startswith(codecs.BOM_UTF8):
-#                     raw = raw.replace(codecs.BOM_UTF8, '', 1)
-#                     # Write to file
-#                     file_open = open(
-#                         os.path.join(csv_rootpath, folder, textfile), 'w')
-#                     file_open.write(raw)
-#                     file_open.close()
-# 
-#     log('GTFS text file encoding check completed. Took {:,.2f} seconds'.format(
-#         time.time() - start_time))
+def _txt_encoder_check(gtfsfiles_to_use,
+                       csv_rootpath=os.path.join(
+                           config.settings.data_folder,
+                           'gtfsfeed_text')):
+    """
+    Standardize all text files inside a GTFS feed for encoding problems.
+    Not yet updated for Python 3.
+
+    Parameters
+    ----------
+    gtfsfiles_to_use : list
+        list of gtfs feed txt files to utilize
+    csv_rootpath : str, optional
+        root path where all gtfs feeds that make up a contiguous metropolitan
+        area are stored
+
+    Returns
+    -------
+    None
+    """
+    # UnicodeDecodeError
+    start_time = time.time()
+
+    folderlist = [foldername for foldername in os.listdir(csv_rootpath) if
+                  os.path.isdir(os.path.join(csv_rootpath, foldername))]
+
+    if not folderlist:
+        folderlist = [csv_rootpath]
+
+    for folder in folderlist:
+        textfilelist = [textfilename for textfilename in
+                        os.listdir(os.path.join(csv_rootpath, folder)) if
+                        textfilename.endswith(".txt")]
+
+        for textfile in textfilelist:
+            if textfile in gtfsfiles_to_use:
+                # Read from file
+                file_open = open(os.path.join(csv_rootpath, folder, textfile))
+                raw = file_open.read()
+                file_open.close()
+                if raw.startswith(codecs.BOM_UTF8):
+                    raw = raw.replace(codecs.BOM_UTF8, '', 1)
+                    # Write to file
+                    file_open = open(
+                        os.path.join(csv_rootpath, folder, textfile), 'w')
+                    file_open.write(raw)
+                    file_open.close()
+
+    log('GTFS text file encoding check completed. Took {:,.2f} seconds'.format(
+        time.time() - start_time))
 
 
 def _txt_header_whitespace_check(gtfsfiles_to_use,

--- a/urbanaccess/gtfsfeeds.py
+++ b/urbanaccess/gtfsfeeds.py
@@ -607,7 +607,6 @@ def _zipfile_type_check(file, feed_url_value):
     -------
     nothing
     """
-    print(file.info())
     if 'zip' not in file.info().get('Content-Type') is True \
             or 'octet' not in file.info().get('Content-Type') is True:
         raise ValueError(

--- a/urbanaccess/gtfsfeeds.py
+++ b/urbanaccess/gtfsfeeds.py
@@ -1,12 +1,11 @@
 import yaml
 import pandas as pd
-import urllib
-from urllib2 import urlopen
 import traceback
 import zipfile
 import os
 import logging as lg
 import time
+from six.moves.urllib.request import urlopen
 
 from urbanaccess.utils import log
 from urbanaccess import config
@@ -469,7 +468,7 @@ def download(data_folder=os.path.join(config.settings.data_folder),
         zipfile_path = ''.join([download_folder, '/', feed_name_key, '.zip'])
 
         if 'http' in feed_url_value:
-            status_code = urllib.urlopen(feed_url_value).getcode()
+            status_code = urlopen(feed_url_value).getcode()
             if status_code == 200:
                 file = urlopen(feed_url_value)
 

--- a/urbanaccess/gtfsfeeds.py
+++ b/urbanaccess/gtfsfeeds.py
@@ -607,8 +607,9 @@ def _zipfile_type_check(file, feed_url_value):
     -------
     nothing
     """
-    if 'zip' not in file.info().dict['content-type'] \
-            is True or 'octet' not in file.info().dict['content-type'] is True:
+    print(file.info())
+    if 'zip' not in file.info().get('Content-Type') is True \
+            or 'octet' not in file.info().get('Content-Type') is True:
         raise ValueError(
             'data requested at {} is not a zipfile. '
             'Data must be a zipfile'.format(feed_url_value))

--- a/urbanaccess/tests/integration/integration_madison.py
+++ b/urbanaccess/tests/integration/integration_madison.py
@@ -9,7 +9,7 @@ start_time = time.time()
 name = 'madison'
 url = 'http://www.gtfs-data-exchange.com/agency/city-of-madison/latest.zip'
 
-print ('-------------------------')
+print('-------------------------')
 print('Starting integration test for {}...'.format(name))
 
 new_feed = {name: url}
@@ -88,4 +88,4 @@ urbanaccess.plot.plot_net(nodes=urbanaccess_nw.net_nodes,
 
 print('{} integration test completed successfully. Took {:,'
       '.2f} seconds'.format(name, time.time() - start_time))
-print ('-------------------------')
+print('-------------------------')

--- a/urbanaccess/tests/integration/integration_sandiego.py
+++ b/urbanaccess/tests/integration/integration_sandiego.py
@@ -8,7 +8,7 @@ start_time = time.time()
 
 name = 'san diego'
 
-print ('-------------------------')
+print('-------------------------')
 print('Starting integration test for {}...'.format(name))
 
 script_path = os.path.dirname(os.path.realpath(__file__))
@@ -69,4 +69,4 @@ urbanaccess.plot.plot_net(nodes=transit_net.transit_nodes,
 
 print('{} integration test completed successfully. Took {:,'
       '.2f} seconds'.format(name, time.time() - start_time))
-print ('-------------------------')
+print('-------------------------')


### PR DESCRIPTION
This PR contains updates to provide Python 3 compatibility.

Most of the codebase is fine; we're already using cross-version syntax for print statements, errors, and integer division. 

### Changes

1. Replaces `urllib2.urlopen` with the `six.moves` version, which automatically maps appropriately onto Python 2.7 and 3.x

2. Replaces `.dict[]` lookup of `urlopen().info()` results with `.get()`

3. Disables text encoding checks for Python 3 (general solution for detecting encodings will be in a future PR)

4. Updates some syntax in the demo notebook

5. Updates the setup script and Travis script for Python 3

### Testing

I've been testing these changes locally using the [demo notebook](https://github.com/UDST/urbanaccess/blob/master/demo/simple_example.ipynb), in Python 2.7 and 3.6. 

This is what the notebook output looks like: [py2.7](http://nbviewer.jupyter.org/urls/dl.dropbox.com/s/vwr3oankzsexku3/simple_example-py27.ipynb), [py3.6](http://nbviewer.jupyter.org/urls/dl.dropbox.com/s/ae423f4isdrodjy/simple_example-py36.ipynb).

The Travis script is updated to run the existing unit tests (minimal), demo notebook, and integration tests in Python 2.7, 3.5, and 3.6 (Travis doesn't support 3.7 smoothly yet).

UrbanAccess still requires Pandana v0.3; will add support for v0.4 in a separate PR.

### Outstanding issues

The last three cells of the demo notebook, with Pandana plot commands, won't run on my machine either before or after this PR. They cause the kernel to die. (Mac OS 10.14, 32 GB RAM, Pandana 0.3, tried both Python 2.7 + Matplotlib 2 and Python 3.6 + Matplotlib 3.) 

In Travis, it runs in Python 2.7 and often fails in Python 3. I am commenting out the code in these cells for the time being. (This is mostly resolved with Pandana 0.4; see PR #46.)

### Versioning

This PR is labeled `0.2.dev1` in `setup.py` and the top-level `__init__.py`