### PR TITLE
as_matrix deprecated

### DIFF
--- a/urbanaccess/network.py
+++ b/urbanaccess/network.py
@@ -61,9 +61,14 @@ def _nearest_neighbor(df1, df2):
     df1.index.values[indexes] : pandas.Series
         index of records in df1 that are nearest to the coordinates in df2
     """
-
-    kdt = KDTree(df1.as_matrix())
-    indexes = kdt.query(df2.as_matrix(), k=1, return_distance=False)
+    try:
+        df1_matrix = df1.to_numpy()
+        df2_matrix = df2.to_numpy()
+    except:
+        df1_matrix = df1.values
+        df2_matrix = df2.values
+    kdt = KDTree(df1_matrix)
+    indexes = kdt.query(df2_matrix, k=1, return_distance=False)
     return df1.index.values[indexes]
 
 

--- a/urbanaccess/tests/test_network.py
+++ b/urbanaccess/tests/test_network.py
@@ -1,0 +1,39 @@
+import pytest
+import pandas as pd
+from urbanaccess import network
+
+
+@pytest.fixture
+def nearest_neighbor_dfs():
+    data = {
+        'id': (1, 2, 3),
+        'x': [-122.267546, -122.264479, -122.219119],
+        'y': [37.802919, 37.808042, 37.782288]
+    }
+    osm_nodes = pd.DataFrame(data).set_index('id')
+
+    data = {
+        'node_id_route': ['1_transit_a', '2_transit_a',
+                          '3_transit_a', '4_transit_a'],
+        'x': [-122.265417, -122.266910, -122.269741, -122.238638],
+        'y': [37.806372, 37.802687, 37.799480, 37.797234]
+    }
+    transit_nodes = pd.DataFrame(data).set_index('node_id_route')
+
+    data = {'node_id_route': ['1_transit_a', '2_transit_a',
+                              '3_transit_a', '4_transit_a'],
+            'nearest_osm_node': [2, 1, 1, 3]}
+    index = range(4)
+    expected_transit_nodes = pd.concat(
+        [transit_nodes, pd.DataFrame(data, index).set_index('node_id_route')],
+        axis=1)
+    return osm_nodes, transit_nodes, expected_transit_nodes
+
+
+def test_nearest_neighbor(nearest_neighbor_dfs):
+    osm_nodes, transit_nodes, expected_transit_nodes = nearest_neighbor_dfs
+    transit_nodes['nearest_osm_node'] = network._nearest_neighbor(
+        osm_nodes[['x', 'y']],
+        transit_nodes[['x', 'y']])
+
+    assert expected_transit_nodes.equals(transit_nodes)


### PR DESCRIPTION
as_matrix() has been deprecated from pandas since version 0.23.0. 
Pandas recommends using `df.to_numpy` (available from version 0.24.0.) or `df.values` .
As_matrix() is used `_nearest_neighbor` function in `urban access.network`. 
Solving comment #60  .