### PR TITLE
Enhancement/default txt encoding from config

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ pycodestyle
 # testing demo notebook
 jupyter
 cartopy  # requires conda
+pyepsg
 
 # building documentation
 numpydoc

--- a/urbanaccess/config.py
+++ b/urbanaccess/config.py
@@ -51,8 +51,9 @@ class urbanaccess_config(object):
     log_filename : str
         name of the log file
     txt_encoding : str
-        default encoding to use to read and write GTFS txt files. Must be
-        a valid encoding recognized by Python codecs.
+        default text encoding used by the GTFS files, to be passed to
+        Python's open() function. Must be a valid encoding recognized by
+        Python codecs.
     gtfs_api : dict
         dictionary of the name of the GTFS API service as the key and
         the GTFS API server root URL as the value to pass to the GTFS loader

--- a/urbanaccess/config.py
+++ b/urbanaccess/config.py
@@ -16,7 +16,8 @@ def _format_check(settings):
     """
 
     valid_keys = ['data_folder', 'logs_folder', 'log_file',
-                  'log_console', 'log_name', 'log_filename', 'gtfs_api']
+                  'log_console', 'log_name', 'log_filename',
+                  'txt_encoding', 'gtfs_api']
 
     for key in settings.keys():
         if key not in valid_keys:
@@ -49,6 +50,9 @@ class urbanaccess_config(object):
         name of the logger
     log_filename : str
         name of the log file
+    txt_encoding : str
+        default encoding to use to read and write GTFS txt files. Must be
+        a valid encoding recognized by Python codecs.
     gtfs_api : dict
         dictionary of the name of the GTFS API service as the key and
         the GTFS API server root URL as the value to pass to the GTFS loader
@@ -61,6 +65,7 @@ class urbanaccess_config(object):
                  log_console=False,
                  log_name='urbanaccess',
                  log_filename='urbanaccess',
+                 txt_encoding='utf-8',
                  gtfs_api={'gtfsdataexch': (
                          'http://www.gtfs-data-exchange.com/'
                          'api/agencies?format=csv')}):
@@ -71,6 +76,7 @@ class urbanaccess_config(object):
         self.log_console = log_console
         self.log_name = log_name
         self.log_filename = log_filename
+        self.txt_encoding = txt_encoding
         self.gtfs_api = gtfs_api
 
     @classmethod
@@ -110,6 +116,7 @@ class urbanaccess_config(object):
                        log_name=yaml_config.get('log_name', 'urbanaccess'),
                        log_filename=yaml_config.get('log_filename',
                                                     'urbanaccess'),
+                       txt_encoding=yaml_config.get('txt_encoding', 'utf-8'),
                        gtfs_api=yaml_config.get('gtfs_api', {
                            'gtfsdataexch':
                                ('http://www.gtfs-data-exchange.com/'
@@ -128,6 +135,7 @@ class urbanaccess_config(object):
                 'log_console': self.log_console,
                 'log_name': self.log_name,
                 'log_filename': self.log_filename,
+                'txt_encoding': self.txt_encoding,
                 'gtfs_api': self.gtfs_api,
                 }
 

--- a/urbanaccess/config.py
+++ b/urbanaccess/config.py
@@ -21,7 +21,7 @@ def _format_check(settings):
 
     for key in settings.keys():
         if key not in valid_keys:
-            raise ValueError('{} not found in list of valid configuation '
+            raise ValueError('{} not found in list of valid configuration '
                              'keys'.format(key))
         if not isinstance(key, str):
             raise ValueError('{} must be a string'.format(key))
@@ -43,9 +43,9 @@ class urbanaccess_config(object):
     logs_folder : str
         location to write log files
     log_file : bool
-        if true, save log output to a log file in logs_folder
+        if True, save log output to a log file in logs_folder
     log_console : bool
-        if true, print log output to the console
+        if True, print log output to the console
     log_name : str
         name of the logger
     log_filename : str

--- a/urbanaccess/gtfs/load.py
+++ b/urbanaccess/gtfs/load.py
@@ -4,6 +4,7 @@ import re
 import time
 import pandas as pd
 import six
+import logging as lg
 
 from urbanaccess import config
 from urbanaccess.utils import log
@@ -59,6 +60,7 @@ def _txt_encoder_check(gtfsfiles_to_use,
     """
     # UnicodeDecodeError
     start_time = time.time()
+    log('Checking GTFS text file for encoding issues...')
 
     folderlist = [foldername for foldername in os.listdir(csv_rootpath) if
                   os.path.isdir(os.path.join(csv_rootpath, foldername))]
@@ -74,14 +76,16 @@ def _txt_encoder_check(gtfsfiles_to_use,
         for textfile in textfilelist:
             if textfile in gtfsfiles_to_use:
                 # Read from file
-                file_open = open(os.path.join(csv_rootpath, folder, textfile))
+                file_path = os.path.join(csv_rootpath, folder, textfile)
+                file_open = open(file_path)
                 raw = file_open.read()
                 file_open.close()
                 if raw.startswith(codecs.BOM_UTF8):
+                    msg = 'Correcting encoding issue in: {}...'
+                    log(msg.format(file_path))
                     raw = raw.replace(codecs.BOM_UTF8, '', 1)
                     # Write to file
-                    file_open = open(
-                        os.path.join(csv_rootpath, folder, textfile), 'w')
+                    file_open = open(file_path, 'w')
                     file_open.write(raw)
                     file_open.close()
 

--- a/urbanaccess/gtfs/load.py
+++ b/urbanaccess/gtfs/load.py
@@ -20,7 +20,7 @@ def _standardize_txt(csv_rootpath=os.path.join(config.settings.data_folder,
     Parameters
     ----------
     csv_rootpath : str, optional
-        root path where all gtfs feeds that make up a contiguous metropolitan
+        root path where all GTFS feeds that make up a contiguous metropolitan
         area are stored
 
     Returns
@@ -100,9 +100,9 @@ def _txt_header_whitespace_check(gtfsfiles_to_use,
     Parameters
     ----------
     gtfsfiles_to_use : list
-        list of gtfs feed txt files to utilize
+        list of GTFS feed txt files to utilize
     csv_rootpath : str, optional
-        root path where all gtfs feeds that make up a contiguous metropolitan
+        root path where all GTFS feeds that make up a contiguous metropolitan
         area are stored
 
     Returns
@@ -156,7 +156,7 @@ def gtfsfeed_to_df(gtfsfeed_path=None, validation=False, verbose=True,
     Parameters
     ----------
     gtfsfeed_path : str, optional
-        root path where all gtfs feeds that make up a contiguous metropolitan
+        root path where all GTFS feeds that make up a contiguous metropolitan
         area are stored
     validation : bool
         if true, the validation check on stops checking for stops outside

--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -58,7 +58,7 @@ def create_transit_net(gtfsfeeds_dfs, day,
         DataFrame for the same time period stored in the
         gtfsfeeds_dfs object it will be used instead of re-calculated
     save_processed_gtfs : bool, optional
-        if true, all processed gtfs DataFrames will
+        if true, all processed GTFS DataFrames will
         be stored to disk in a hdf5 file
     save_dir : str, optional
         directory to save the hdf5 file
@@ -216,7 +216,7 @@ def _trip_schedule_selector(input_trips_df, input_calendar_df,
         day in the GTFS calendar
     calendar_dates_lookup : dict, optional
         dictionary of the lookup column (key) as a string and corresponding
-        string (value) a s string or list of strings to use to subset trips
+        string (value) as string or list of strings to use to subset trips
         using the calendar_dates DataFrame. Search will be exact. If none,
         then the calendar_dates DataFrame will not be used to select trips
         that are not in the calendar DataFrame. Note search will select all


### PR DESCRIPTION
addresses #79 by adding a default encoding parameter to the urbanaccess configuration object and allows for user to change encoding if needed. Solves issues where user machine encoding is different than expected txt encoding.

- adds `txt_encoding` parameter to config with 'utf-8' default. This parameter is used when txt files are read with functions in _standardize_txt().
- updates _txt_header_whitespace_check() to use encoding from config, updates function for use with py2 vs py3 since py2 does not support encoding parameter, update to only modify txt files that have whitespace issues, and added prints
- adds prints to _txt_encoder_check()
- adds unit tests for functions in _standardize_txt()