### PR TITLE
Preparing v0.2.2 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ v0.2.2
 
 2020/11/09
 
-* allows passing matplotlib axes to pandana.plot.plot_net()
+* allows passing matplotlib axes to urbanaccess.plot.plot_net()
 * adds flexibility to calendar/date handling (calendar_dates.txt now supported)
 * improves GTFS downloading (solves issue where requests were rejected due to missing user agent header)
 * improves text encoding support

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+v0.2.2
+======
+
+2020/11/09
+
+* allows passing matplotlib axes to pandana.plot_net()
+* adds flexibility to calendar/date handling
+* improves GTFS downloading
+* improves text encoding support
+
 v0.2.1
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,8 @@ v0.2.2
 2020/11/09
 
 * allows passing matplotlib axes to pandana.plot_net()
-* adds flexibility to calendar/date handling
-* improves GTFS downloading
+* adds flexibility to calendar/date handling (calendar_dates.txt now supported)
+* improves GTFS downloading (solves issue where requests were rejected due to missing user agent header)
 * improves text encoding support
 
 v0.2.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ v0.2.2
 
 2020/11/09
 
-* allows passing matplotlib axes to pandana.plot_net()
+* allows passing matplotlib axes to pandana.plot.plot_net()
 * adds flexibility to calendar/date handling (calendar_dates.txt now supported)
 * improves GTFS downloading (solves issue where requests were rejected due to missing user agent header)
 * improves text encoding support

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ master_doc = 'index'
 project = u'UrbanAccess'
 author = u'UrbanSim Inc.'
 copyright = u'{}, {}'.format(datetime.now().year, author)
-version = u'0.2.1'
-release = u'0.2.1'
+version = u'0.2.2'
+release = u'0.2.2'
 language = None
 
 # List of patterns to ignore when looking for source files.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ UrbanAccess
 
 A tool for computing GTFS transit and OSM pedestrian networks for accessibility analysis.
 
-v0.2.1, released August 28, 2020.
+v0.2.2, released November 9, 2020.
 
 Contents
 --------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ description = 'A tool for creating GTFS transit and OSM pedestrian networks ' \
 
 setup(
     name='urbanaccess',
-    version='0.2.1',
+    version='0.2.2',
     license='AGPL',
     description=description,
     long_description=long_description,

--- a/urbanaccess/__init__.py
+++ b/urbanaccess/__init__.py
@@ -9,6 +9,6 @@ from .utils import *
 from .gtfsfeeds import *
 from .plot import *
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 version = __version__


### PR DESCRIPTION
This PR prepares the v0.2.2 release.

Previously merged:
- allows passing matplotlib axes to `urbanaccess.plot.plot_net()` (PR #68, thanks @dapid!)
- adds flexibility to calendar/date handling (PR #69, thanks @knaaptime!)
- adds user agent headers for GTFS download (PR #74, thanks to @knaaptime for bug report and initial solution)
- improves text encoding support (PR #80, thanks to @ar-kan for bug report)
- updates unit tests (PR #73)

This PR:
- updates version numbers
- updates change log
- updates versioning in docs

Release logistics:
- [x] release on pypi
- [x] release on conda-forge
- [x] update live docs
- [ ] merge dev to master and tag on GitHub

Anything else to include?