### PR TITLE
Enhancement/remove whitespace from relational cols

### DIFF
--- a/urbanaccess/gtfs/network.py
+++ b/urbanaccess/gtfs/network.py
@@ -488,6 +488,12 @@ def _interpolate_stop_times(stop_times_df, calendar_selected_trips_df):
     stop_times_df = stop_times_df[
         stop_times_df['unique_trip_id'].isin(uniquetriplist)]
 
+    # if there were no records that match then do not proceed and throw error
+    if len(stop_times_df) == 0:
+        raise ValueError('No matching trip_ids where found. Suggest checking '
+                         'for differences between trip_id values in '
+                         'stop_times and trips GTFS files.')
+
     # count missing stop times
     missing_stop_times_count = stop_times_df[
         'departure_time_sec'].isnull().sum()

--- a/urbanaccess/gtfs/utils_format.py
+++ b/urbanaccess/gtfs/utils_format.py
@@ -14,7 +14,7 @@ def _read_gtfs_agency(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 
@@ -41,7 +41,7 @@ def _read_gtfs_stops(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 
@@ -74,7 +74,7 @@ def _read_gtfs_routes(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 
@@ -102,7 +102,7 @@ def _read_gtfs_trips(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 
@@ -135,7 +135,7 @@ def _read_gtfs_stop_times(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 
@@ -166,7 +166,7 @@ def _read_gtfs_calendar(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 
@@ -201,7 +201,7 @@ def _read_gtfs_calendar_dates(textfile_path, textfile):
     Parameters
     ----------
     textfile_path : str
-        director of text file
+        directory of text file
     textfile : str
         name of text file
 


### PR DESCRIPTION
- addresses cases such as #84 where incoming GTFS feed columns that are relational columns used for table joins and lookups have leading or trailing spaces in their values and ensures these relational column values are identical between different GTFS txt files.
- adds a ValueError when no `trip_id`s match between `trips` and `stop_times` table
- refactors existing leading or trailing space removal in txt file column names into function with informative print if spaces are found